### PR TITLE
SIK-2364: Update api v2 path

### DIFF
--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -28,7 +28,7 @@ class GundiClient:
         # API settings
         self.gundi_version = "v2"
         self.base_url = kwargs.get("base_url", settings.GUNDI_API_BASE_URL)
-        self.api_base_path = f"{self.base_url}/api/{self.gundi_version}"
+        self.api_base_path = f"{self.base_url}/{self.gundi_version}"
         self.connections_endpoint = f"{self.api_base_path}/connections"
         self.integrations_endpoint = f"{self.api_base_path}/integrations"
         self.source_states_endpoint = f"{self.api_base_path}/sources/states"

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,13 +85,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.6"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.6-py3-none-any.whl", hash = "sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5"},
-    {file = "click-8.1.6.tar.gz", hash = "sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [package.dependencies]
@@ -132,13 +132,13 @@ tests = ["dj-database-url", "dj-email-url", "django-cache-url", "pytest"]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.2"
+version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
-    {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
 ]
 
 [package.extras]
@@ -146,13 +146,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "gundi-core"
-version = "1.2.1"
+version = "1.2.6"
 description = ""
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "gundi_core-1.2.1-py3-none-any.whl", hash = "sha256:6a19adb4d73631a0bd684b78a3f920d889d7c494a03745c19ee1400f6e825812"},
-    {file = "gundi_core-1.2.1.tar.gz", hash = "sha256:c8dcda563767646d24c0df47b4910237c2cda0edfe28b87f982d314f5babaf2d"},
+    {file = "gundi_core-1.2.6-py3-none-any.whl", hash = "sha256:c5a7e1cc7880fb05e4e2dc2a0ab04e72a661f14e2eb17d02e45cf2edd9bc0e6d"},
+    {file = "gundi_core-1.2.6.tar.gz", hash = "sha256:cf0e2210e727c158c4689eb0c65c398cbaefba03f6a4ea7df710d7d3669c8083"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-client-v2"
-version = "2.1.1"
+version = "2.1.2"
 description = "An async client for Gundi's API"
 authors = [
     "Chris Doehring <chrisdo@earthranger.com>",


### PR DESCRIPTION
### What does this PR do?
- Remove `/api/` from the URL path in v2, so the full api URL can be `api.gundiservice.org/v2/`
- This is covered by regression tests.

### Relevant link(s)
[SIK-2364](https://allenai.atlassian.net/browse/SIK-2364)

[SIK-2364]: https://allenai.atlassian.net/browse/SIK-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ