### PR TITLE
Include support for attachments in events

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,2 +1,2 @@
-from .client import GundiClient
+from .client import GundiClient, GundiDataSenderClient
 from . import errors

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -36,7 +36,10 @@ class GundiDataSenderClient:
     async def post_events(self, data: List[dict]) -> dict:
         return await self._post_data(data=data, endpoint="events")
 
-    async def _post_data(self, data: List[dict], endpoint: str) -> dict:
+    async def post_event_attachment(self, event_id: str, attachment: dict) -> dict:
+        return await self._post_data(attachment=attachment, endpoint=f"events/{event_id}/attachments")
+
+    async def _post_data(self, data: List[dict] = None, endpoint: str = None, attachment: dict = None) -> dict:
         apikey = self._api_key
 
         logger.info(
@@ -44,23 +47,32 @@ class GundiDataSenderClient:
             extra={"integration_api_key": apikey}
         )
 
-        clean_batch = [json.loads(json.dumps(r, default=str)) for r in data]
         url = f"{self.sensors_api_endpoint}/{endpoint}/"
+
+        request = dict(
+            url=url,
+            headers={"apikey": apikey}
+        )
+
+        if data:
+            clean_batch = [json.loads(json.dumps(r, default=str)) for r in data]
+            request["json"] = clean_batch
+
+        # attachment needs to have the following format:
+        # attachment = {'upload-file': <IMAGE_IN_BYTES>}
+        if attachment:
+            request["files"] = attachment
 
         logger.debug(
             f" -- sending {endpoint}. --",
             extra={
-                "length": len(data),
+                "length": len(data or attachment),
                 "api": url,
             },
         )
 
         async with httpx.AsyncClient(timeout=120) as session:
-            client_response = await session.post(
-                url=url,
-                headers={"apikey": apikey},
-                json=clean_batch,
-            )
+            client_response = await session.post(**request)
 
         client_response.raise_for_status()
 

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -36,10 +36,10 @@ class GundiDataSenderClient:
     async def post_events(self, data: List[dict]) -> dict:
         return await self._post_data(data=data, endpoint="events")
 
-    async def post_event_attachment(self, event_id: str, attachment: dict) -> dict:
-        return await self._post_data(attachment=attachment, endpoint=f"events/{event_id}/attachments")
+    async def post_event_attachments(self, event_id: str, attachments: List[bytes]) -> dict:
+        return await self._post_data(attachments=attachments, endpoint=f"events/{event_id}/attachments")
 
-    async def _post_data(self, data: List[dict] = None, endpoint: str = None, attachment: dict = None) -> dict:
+    async def _post_data(self, data: List[dict] = None, endpoint: str = None, attachments: List[bytes] = None) -> dict:
         apikey = self._api_key
 
         logger.info(
@@ -58,15 +58,13 @@ class GundiDataSenderClient:
             clean_batch = [json.loads(json.dumps(r, default=str)) for r in data]
             request["json"] = clean_batch
 
-        # attachment needs to have the following format:
-        # attachment = {'upload-file': <IMAGE_IN_BYTES>}
-        if attachment:
-            request["files"] = attachment
+        if attachments:
+            request["files"] = [('file', image_binary) for image_binary in attachments]
 
         logger.debug(
             f" -- sending {endpoint}. --",
             extra={
-                "length": len(data or attachment),
+                "length": len(data or attachments),
                 "api": url,
             },
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-client-v2"
-version = "2.3.0"
+version = "2.3.1"
 description = "An async client for Gundi's API"
 authors = [
     "Chris Doehring <chrisdo@earthranger.com>",

--- a/tests/client/test_data_sender.py
+++ b/tests/client/test_data_sender.py
@@ -39,7 +39,7 @@ async def test_post_events(
 
 @pytest.mark.asyncio
 async def test_post_event_attachment(
-    gundi_data_sender_client_v2, event_attachment_payload, events_created_response
+    gundi_data_sender_client_v2, event_attachment_payload
 ):
     async with respx.mock(assert_all_called=False) as gundi_api_mock:
         # Mock API response

--- a/tests/client/test_data_sender.py
+++ b/tests/client/test_data_sender.py
@@ -39,7 +39,7 @@ async def test_post_events(
 
 @pytest.mark.asyncio
 async def test_post_event_attachment(
-    gundi_data_sender_client_v2, event_attachment_payload
+    gundi_data_sender_client_v2, event_attachment_payload, event_attachment_created_response
 ):
     async with respx.mock(assert_all_called=False) as gundi_api_mock:
         # Mock API response
@@ -47,9 +47,33 @@ async def test_post_event_attachment(
         events_endpoint = f"{gundi_data_sender_client_v2.sensors_api_endpoint}/events/{event_id}/attachments/"
         events_api_mock = gundi_api_mock.post(events_endpoint).respond(
             status_code=httpx.codes.OK,
-            json={}
+            json=event_attachment_created_response
         )
 
-        response = await gundi_data_sender_client_v2.post_event_attachment(event_id, event_attachment_payload)
-        assert response is not None
+        response = await gundi_data_sender_client_v2.post_event_attachments(event_id, [event_attachment_payload])
+        assert response == event_attachment_created_response
+        assert events_api_mock.called
+
+
+@pytest.mark.asyncio
+async def test_post_multiple_event_attachment(
+    gundi_data_sender_client_v2,
+    event_attachment_payload,
+    another_event_attachment_payload,
+    event_attachment_created_response
+):
+    async with respx.mock(assert_all_called=False) as gundi_api_mock:
+        # Mock API response
+        event_id = "dummy-123"
+        events_endpoint = f"{gundi_data_sender_client_v2.sensors_api_endpoint}/events/{event_id}/attachments/"
+        events_api_mock = gundi_api_mock.post(events_endpoint).respond(
+            status_code=httpx.codes.OK,
+            json=event_attachment_created_response
+        )
+
+        response = await gundi_data_sender_client_v2.post_event_attachments(
+            event_id,
+            [event_attachment_payload, another_event_attachment_payload]
+        )
+        assert response == event_attachment_created_response
         assert events_api_mock.called

--- a/tests/client/test_data_sender.py
+++ b/tests/client/test_data_sender.py
@@ -46,10 +46,10 @@ async def test_post_event_attachment(
         event_id = "dummy-123"
         events_endpoint = f"{gundi_data_sender_client_v2.sensors_api_endpoint}/events/{event_id}/attachments/"
         events_api_mock = gundi_api_mock.post(events_endpoint).respond(
-            status_code=httpx.codes.CREATED,
-            json=events_created_response
+            status_code=httpx.codes.OK,
+            json={}
         )
 
         response = await gundi_data_sender_client_v2.post_event_attachment(event_id, event_attachment_payload)
-        assert response == events_created_response
+        assert response is not None
         assert events_api_mock.called

--- a/tests/client/test_data_sender.py
+++ b/tests/client/test_data_sender.py
@@ -35,3 +35,21 @@ async def test_post_events(
         response = await gundi_data_sender_client_v2.post_events([event_payload])
         assert response == events_created_response
         assert events_api_mock.called
+
+
+@pytest.mark.asyncio
+async def test_post_event_attachment(
+    gundi_data_sender_client_v2, event_attachment_payload, events_created_response
+):
+    async with respx.mock(assert_all_called=False) as gundi_api_mock:
+        # Mock API response
+        event_id = "dummy-123"
+        events_endpoint = f"{gundi_data_sender_client_v2.sensors_api_endpoint}/events/{event_id}/attachments/"
+        events_api_mock = gundi_api_mock.post(events_endpoint).respond(
+            status_code=httpx.codes.CREATED,
+            json=events_created_response
+        )
+
+        response = await gundi_data_sender_client_v2.post_event_attachment(event_id, event_attachment_payload)
+        assert response == events_created_response
+        assert events_api_mock.called

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -403,6 +403,13 @@ def event_payload():
 
 
 @pytest.fixture
+def event_attachment_payload():
+    return {
+        'upload-file': b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x01\x00x\x00x\x00\x00\xff\xdb\x00C\x00\x02\x01\x01\x02'
+    }
+
+
+@pytest.fixture
 def events_created_response():
     return [
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -404,9 +404,14 @@ def event_payload():
 
 @pytest.fixture
 def event_attachment_payload():
-    return {
-        'upload-file': b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x01\x00x\x00x\x00\x00\xff\xdb\x00C\x00\x02\x01\x01\x02'
-    }
+    # Representation of an image in binary format
+    return b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x01\x00x\x00x\x00\x00\xff\xdb\x00C\x00\x02\x01\x01\x02'
+
+
+@pytest.fixture
+def another_event_attachment_payload():
+    # Representation of an image in binary format
+    return b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x06\x01\x01\x00x\x00x\x01\x00\xff\xd5\x00C\x00\x98\x01\x01\x56'
 
 
 @pytest.fixture
@@ -415,6 +420,17 @@ def events_created_response():
         {
             "object_id": "abebe106-3c50-446b-9c98-0b9b503fc900",
             "created_at": "2023-11-16T19:59:50.612864Z"
+        }
+    ]
+
+
+@pytest.fixture
+def event_attachment_created_response():
+    return [
+        {
+            "object_id": "af8e2946-bad6-4d02-8a26-99dde34bd9fa",
+            "created_at": "2024-07-04T13:15:26.559894Z",
+            "updated_at": None
         }
     ]
 


### PR DESCRIPTION
- Little refactor to `_post_data` method to allow file attachments in requests.

**Example of file attachment (in request):**

`attachment = {'upload-file': <IMAGE_IN_BYTES>}`

- Test case added