### PR TITLE
Update respx version requirements in v2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -146,13 +146,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "gundi-core"
-version = "1.5.8"
+version = "1.6.1"
 description = ""
 optional = false
 python-versions = "<4.0,>=3.7"
 files = [
-    {file = "gundi_core-1.5.8-py3-none-any.whl", hash = "sha256:61e264e9c0fe99ffb6c97bcaddf96dc90b16a63972e37db8910c34032b9fa071"},
-    {file = "gundi_core-1.5.8.tar.gz", hash = "sha256:7ba9b4a83c6a96d05db272b8fdf86f4316eecde587af860983bdf4f5ed012fba"},
+    {file = "gundi_core-1.6.1-py3-none-any.whl", hash = "sha256:9eb5d04d9ecaf03fc718d3c72312edc59e440c37d2c4f96bb98362440ab87ddb"},
+    {file = "gundi_core-1.6.1.tar.gz", hash = "sha256:cb412981b7f3448be48c7467419a12d5eef783f1d227306e6ffa91364cc4962f"},
 ]
 
 [package.dependencies]
@@ -464,13 +464,13 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "respx"
-version = "0.20.2"
+version = "0.21.1"
 description = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "respx-0.20.2-py2.py3-none-any.whl", hash = "sha256:ab8e1cf6da28a5b2dd883ea617f8130f77f676736e6e9e4a25817ad116a172c9"},
-    {file = "respx-0.20.2.tar.gz", hash = "sha256:07cf4108b1c88b82010f67d3c831dae33a375c7b436e54d87737c7f9f99be643"},
+    {file = "respx-0.21.1-py2.py3-none-any.whl", hash = "sha256:05f45de23f0c785862a2c92a3e173916e8ca88e4caad715dd5f68584d6053c20"},
+    {file = "respx-0.21.1.tar.gz", hash = "sha256:0bd7fe21bfaa52106caa1223ce61224cf30786985f17c63c5d71eff0307ee8af"},
 ]
 
 [package.dependencies]
@@ -577,4 +577,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "ce968e53e6284740342801a8c5a811f9e6edae99936c23dd79c42158d257bae5"
+content-hash = "d9a47e1d99dd01ecfb7f8de04f01cbc71876ed83e65247821c34361254a84598"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gundi-client-v2"
-version = "2.3.4"
+version = "2.3.5"
 description = "An async client for Gundi's API"
 authors = [
     "Chris Doehring <chrisdo@earthranger.com>",
@@ -19,7 +19,7 @@ python = "^3.7"
 environs = "^9.5"
 pydantic = "^1.10"
 httpx = "^0.24.0"
-respx = "^0.20.1"
+respx = "^0"
 gundi-core = "^1.5.8"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Same as https://github.com/PADAS/gundi-client/pull/24 but for v2