### PR TITLE
GUNDI-4346: Support text messages in v2 client

### DIFF
--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -36,6 +36,9 @@ class GundiDataSenderClient:
     async def post_events(self, data: List[dict]) -> dict:
         return await self._post_data(data=data, endpoint="events")
 
+    async def post_messages(self, data: List[dict]) -> dict:
+        return await self._post_data(data=data, endpoint="messages")
+
     async def update_event(self, event_id: str, data: dict) -> dict:
         return await self._update_data(data=data, endpoint=f"events/{event_id}")
 

--- a/tests/client/test_data_sender.py
+++ b/tests/client/test_data_sender.py
@@ -38,6 +38,23 @@ async def test_post_events(
 
 
 @pytest.mark.asyncio
+async def test_post_messages(
+    gundi_data_sender_client_v2, message_payload, messages_created_response
+):
+    async with respx.mock(assert_all_called=False) as gundi_api_mock:
+        # Mock API response
+        messages_endpoint = f"{gundi_data_sender_client_v2.sensors_api_endpoint}/messages/"
+        messages_api_mock = gundi_api_mock.post(messages_endpoint).respond(
+            status_code=httpx.codes.CREATED,
+            json=messages_created_response
+        )
+
+        response = await gundi_data_sender_client_v2.post_messages([message_payload])
+        assert response == messages_created_response
+        assert messages_api_mock.called
+
+
+@pytest.mark.asyncio
 async def test_post_event_attachment(
     gundi_data_sender_client_v2, event_attachment_payload, event_attachment_created_response
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -403,6 +403,28 @@ def event_payload():
 
 
 @pytest.fixture
+def message_payload():
+    return {
+        "sender": "2075752244",
+        "recipients": ["admin@sitex.pamdas.org"],
+        "text": "Assistance needed at the site.",
+        "recorded_at": "2025-06-06 09:50:10-0300",
+        "location": {
+            "latitude": -51.689,
+            "longitude": -72.717
+        },
+        "additional": {
+            "status": {
+                "autonomous": 0,
+                "lowBattery": 1,
+                "intervalChange": 0,
+                "resetDetected": 0
+            }
+        }
+    }
+
+
+@pytest.fixture
 def event_attachment_payload():
     # Representation of an image in binary format
     return ("file1.png", b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x01\x00x\x00x\x00\x00\xff\xdb\x00C\x00\x02\x01\x01\x02')
@@ -423,6 +445,13 @@ def events_created_response():
         }
     ]
 
+@pytest.fixture
+def messages_created_response():
+    return {
+        "object_id": "998ac464-07d1-45af-8c5a-701d5171cc99",
+        "created_at": "2025-06-06T18:48:27.207038Z",
+        "updated_at": None
+    }
 
 @pytest.fixture
 def event_attachment_created_response():


### PR DESCRIPTION
This pull request introduces functionality for posting messages to the `gundi_client_v2` API and adds corresponding test coverage. The most important changes include the addition of a `post_messages` method, a new test for this method, and supporting fixtures for the test.

### New functionality for posting messages:
* [`gundi_client_v2/client.py`](diffhunk://#diff-e0a741791357c46a948edc6e1e7970172499b30e0de527e273a05dd25d9df09bR39-R41): Added a new `post_messages` method to send message data to the `messages` endpoint.

### Test coverage for `post_messages`:
* [`tests/client/test_data_sender.py`](diffhunk://#diff-8156aed441aa30aaa34f6e2711518ff572a185ee876bac94eb796ddad074b1d3R40-R56): Added a new test, `test_post_messages`, to verify the functionality of the `post_messages` method, including mocking the API response.

### Supporting test fixtures:
* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R405-R426): Added a `message_payload` fixture to provide sample message data for testing.
* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R448-R454): Added a `messages_created_response` fixture to mock the API's response when a message is successfully created.