### PR TITLE
refactor: prefer oauth_* config with keycloak_* fallback; fix 302 retry

### DIFF
--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -136,11 +136,15 @@ class GundiClient:
         self.traces_endpoint = f"{self.api_base_path}/traces"
 
         # Authentication settings
+        # New oauth_* names preferred; keycloak_* still accepted for backward compatibility
         self.ssl_verify = kwargs.get("use_ssl", settings.GUNDI_API_SSL_VERIFY)
-        self.client_id = kwargs.get("keycloak_client_id", settings.KEYCLOAK_CLIENT_ID)
-        self.client_secret = kwargs.get("keycloak_client_secret", settings.KEYCLOAK_CLIENT_SECRET)
+        self.client_id = kwargs.get("oauth_client_id",
+                                    kwargs.get("keycloak_client_id", settings.OAUTH_CLIENT_ID))
+        self.client_secret = kwargs.get("oauth_client_secret",
+                                        kwargs.get("keycloak_client_secret", settings.OAUTH_CLIENT_SECRET))
         self.oauth_token_url = kwargs.get("oauth_token_url", settings.OAUTH_TOKEN_URL)
-        self.audience = kwargs.get("keycloak_audience", settings.KEYCLOAK_AUDIENCE)
+        self.audience = kwargs.get("oauth_audience",
+                                   kwargs.get("keycloak_audience", settings.OAUTH_AUDIENCE))
         self.cached_token = None
         self.cached_token_expires_at = datetime.min.replace(tzinfo=timezone.utc)
 
@@ -176,11 +180,11 @@ class GundiClient:
         )
         # Force refresh the token and retry if we get redirected to the login page
         if response.status_code == 302 and "auth/realms" in response.headers.get("location", ""):
-            headers = await self.get_auth_header(force_refresh_token=True)
+            auth_headers = await self.get_auth_header(force_refresh_token=True)
             response = await self._session.get(
                 url,
                 params=params,
-                headers=headers,
+                headers={**auth_headers, **headers},
                 **kwargs,
             )
         return response
@@ -197,10 +201,10 @@ class GundiClient:
         )
         # Force refresh the token and retry if we get redirected to the login page
         if response.status_code == 302 and "auth/realms" in response.headers.get("location", ""):
-            headers = await self.get_auth_header(force_refresh_token=True)
-            await self._session.post(
+            auth_headers = await self.get_auth_header(force_refresh_token=True)
+            response = await self._session.post(
                 url,
-                json=json,
+                json=data,
                 params=params,
                 headers={**auth_headers, **headers},
                 **kwargs,

--- a/gundi_client_v2/settings.py
+++ b/gundi_client_v2/settings.py
@@ -18,6 +18,13 @@ OAUTH_CLIENT_ID = env.str("OAUTH_CLIENT_ID", env.str("KEYCLOAK_CLIENT_ID", None)
 OAUTH_CLIENT_SECRET = env.str("OAUTH_CLIENT_SECRET", env.str("KEYCLOAK_CLIENT_SECRET", None))
 OAUTH_AUDIENCE = env.str("OAUTH_AUDIENCE", env.str("KEYCLOAK_AUDIENCE", None))
 
+# Backward-compatible aliases for the pre-rename setting names. Code importing
+# gundi_client_v2.settings.KEYCLOAK_* keeps working; these mirror the OAUTH_* values.
+KEYCLOAK_ISSUER = OAUTH_ISSUER
+KEYCLOAK_CLIENT_ID = OAUTH_CLIENT_ID
+KEYCLOAK_CLIENT_SECRET = OAUTH_CLIENT_SECRET
+KEYCLOAK_AUDIENCE = OAUTH_AUDIENCE
+
 GUNDI_API_BASE_URL = env.str("GUNDI_API_BASE_URL", None)
 GUNDI_API_SSL_VERIFY = env.bool("GUNDI_API_SSL_VERIFY", True)
 

--- a/gundi_client_v2/settings.py
+++ b/gundi_client_v2/settings.py
@@ -11,11 +11,12 @@ else:
     # Default behavior
     env.read_env()
 
-KEYCLOAK_ISSUER = env.str("KEYCLOAK_ISSUER", None)
-OAUTH_TOKEN_URL = f"{KEYCLOAK_ISSUER}/protocol/openid-connect/token"
-KEYCLOAK_CLIENT_ID = env.str("KEYCLOAK_CLIENT_ID", None)
-KEYCLOAK_CLIENT_SECRET = env.str("KEYCLOAK_CLIENT_SECRET", None)
-KEYCLOAK_AUDIENCE = env.str("KEYCLOAK_AUDIENCE", None)
+# OAuth settings — OAUTH_* preferred; KEYCLOAK_* accepted for backward compatibility
+OAUTH_ISSUER = env.str("OAUTH_ISSUER", env.str("KEYCLOAK_ISSUER", None))
+OAUTH_TOKEN_URL = f"{OAUTH_ISSUER}/protocol/openid-connect/token" if OAUTH_ISSUER else None
+OAUTH_CLIENT_ID = env.str("OAUTH_CLIENT_ID", env.str("KEYCLOAK_CLIENT_ID", None))
+OAUTH_CLIENT_SECRET = env.str("OAUTH_CLIENT_SECRET", env.str("KEYCLOAK_CLIENT_SECRET", None))
+OAUTH_AUDIENCE = env.str("OAUTH_AUDIENCE", env.str("KEYCLOAK_AUDIENCE", None))
 
 GUNDI_API_BASE_URL = env.str("GUNDI_API_BASE_URL", None)
 GUNDI_API_SSL_VERIFY = env.bool("GUNDI_API_SSL_VERIFY", True)

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -57,6 +57,15 @@ async def test_post_retries_on_login_redirect(auth_token_response, gundi_client_
         assert result == IntegrationType.parse_obj(integration_type_payload)
 
 
+def test_keycloak_settings_aliases_preserved():
+    # The pre-rename module constants must remain importable as aliases of the OAUTH_* values.
+    from gundi_client_v2 import settings
+    assert settings.KEYCLOAK_ISSUER == settings.OAUTH_ISSUER
+    assert settings.KEYCLOAK_CLIENT_ID == settings.OAUTH_CLIENT_ID
+    assert settings.KEYCLOAK_CLIENT_SECRET == settings.OAUTH_CLIENT_SECRET
+    assert settings.KEYCLOAK_AUDIENCE == settings.OAUTH_AUDIENCE
+
+
 @pytest.mark.asyncio
 async def test_keycloak_kwargs_backward_compatible():
     client = GundiClient(

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1,0 +1,71 @@
+import httpx
+import pytest
+import respx
+from urllib.parse import parse_qs
+
+from gundi_client_v2.client import GundiClient
+from gundi_core.schemas.v2 import IntegrationType
+
+
+def _token_body(route):
+    return parse_qs(route.calls.last.request.content.decode())
+
+
+@pytest.mark.asyncio
+async def test_authenticates_with_oauth_kwargs(auth_token_response):
+    client = GundiClient(
+        oauth_token_url="https://fakeauth.com/realms/dev/protocol/openid-connect/token",
+        oauth_client_id="confidential-client",
+        oauth_client_secret="shhh",
+        oauth_audience="my-portal",
+        base_url="https://api.fakeportal.com",
+    )
+    async with respx.mock as mock:
+        token_route = mock.post(client.oauth_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        header = await client.get_auth_header()
+        assert header["authorization"].startswith("Bearer ")
+        params = _token_body(token_route)
+        assert params["grant_type"] == ["urn:ietf:params:oauth:grant-type:uma-ticket"]
+        assert params["client_id"] == ["confidential-client"]
+        assert params["client_secret"] == ["shhh"]
+
+
+@pytest.mark.asyncio
+async def test_post_retries_on_login_redirect(auth_token_response, gundi_client_v2):
+    integration_type_payload = {
+        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "name": "Test Integration",
+        "value": "test_integration",
+        "description": "A test integration type",
+        "actions": [],
+    }
+    async with respx.mock(assert_all_called=True) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        type_url = f"{gundi_client_v2.integrations_endpoint}/types/"
+        mock.post(type_url).side_effect = [
+            httpx.Response(
+                status_code=302,
+                headers={"location": "https://cdip-auth.pamdas.org/auth/realms/x/protocol/openid-connect/auth?response_type=code"},
+            ),
+            httpx.Response(status_code=httpx.codes.OK, json=integration_type_payload),
+        ]
+        result = await gundi_client_v2.register_integration_type(integration_type_payload)
+        assert result == IntegrationType.parse_obj(integration_type_payload)
+
+
+@pytest.mark.asyncio
+async def test_keycloak_kwargs_backward_compatible():
+    client = GundiClient(
+        oauth_token_url="https://fakeauth.com/realms/dev/protocol/openid-connect/token",
+        keycloak_client_id="legacy-client",
+        keycloak_client_secret="legacy-secret",
+        keycloak_audience="legacy-aud",
+        base_url="https://api.fakeportal.com",
+    )
+    assert client.client_id == "legacy-client"
+    assert client.client_secret == "legacy-secret"
+    assert client.audience == "legacy-aud"

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -57,6 +57,33 @@ async def test_post_retries_on_login_redirect(auth_token_response, gundi_client_
         assert result == IntegrationType.parse_obj(integration_type_payload)
 
 
+@pytest.mark.asyncio
+async def test_get_retries_on_login_redirect_preserves_custom_headers(
+    auth_token_response, gundi_client_v2
+):
+    # The _get 302-retry must merge the refreshed Authorization header with any
+    # caller-supplied headers (regression guard for the headers={**auth_headers, **headers} fix).
+    async with respx.mock(assert_all_called=True) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        target_url = f"{gundi_client_v2.connections_endpoint}/some-id/"
+        route = mock.get(target_url)
+        route.side_effect = [
+            httpx.Response(
+                status_code=302,
+                headers={"location": "https://cdip-auth.pamdas.org/auth/realms/x/protocol/openid-connect/auth?response_type=code"},
+            ),
+            httpx.Response(status_code=httpx.codes.OK, json={}),
+        ]
+        response = await gundi_client_v2._get(target_url, headers={"x-custom": "val"})
+        assert response.status_code == 200
+        assert route.call_count == 2
+        retried = route.calls[1].request
+        assert retried.headers.get("x-custom") == "val"
+        assert "authorization" in retried.headers
+
+
 def test_keycloak_settings_aliases_preserved():
     # The pre-rename module constants must remain importable as aliases of the OAUTH_* values.
     from gundi_client_v2 import settings


### PR DESCRIPTION
## Summary
PR 2/6. Stacked on #(uv).

- Rename `keycloak_*` kwargs/settings to `oauth_*`, keeping `keycloak_*` as backward-compatible fallbacks
- Guard `OAUTH_TOKEN_URL` derivation against an unset issuer
- Fix the broken `_post` 302-login-retry (referenced an undefined `json`, dropped the retried response) and make `_get`'s retry preserve caller headers

## Test Plan
- [x] `pytest` — 14 passed (incl. new oauth/keycloak-compat and `_post` 302-retry tests)