### PR TITLE
feat: add errors module and route API responses through raise_for_status

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,5 @@
 __version__ = "2.4.1"
 
 from .client import GundiClient, GundiDataSenderClient
+from .errors import GundiClientError, AuthenticationError, GundiAPIError
 from . import errors

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -80,7 +80,7 @@ class GundiDataSenderClient:
         async with httpx.AsyncClient(timeout=120) as session:
             client_response = await session.post(**request)
 
-        client_response.raise_for_status()
+        errors.raise_for_status(client_response)
 
         return client_response.json()
 
@@ -113,7 +113,7 @@ class GundiDataSenderClient:
         async with httpx.AsyncClient(timeout=120) as session:
             client_response = await session.patch(**request)
 
-        client_response.raise_for_status()
+        errors.raise_for_status(client_response)
 
         return client_response.json()
 
@@ -236,43 +236,42 @@ class GundiClient:
             "authorization": f"{token_object.token_type} {token_object.access_token}"
         }
 
+    @staticmethod
+    def _raise_for_status(response):
+        errors.raise_for_status(response)
+
     async def get_connection_details(self, integration_id):
         url = f"{self.connections_endpoint}/{integration_id}/"
         response = await self._get(url)
-        # ToDo: Add custom exceptions to handle errors
-        response.raise_for_status()
+        self._raise_for_status(response)
         data = response.json()
         return Connection.parse_obj(data)
 
     async def get_route_details(self, route_id):
         url = f"{self.routes_endpoint}/{route_id}/"
         response = await self._get(url)
-        # ToDo: Add custom exceptions to handle errors
-        response.raise_for_status()
+        self._raise_for_status(response)
         data = response.json()
         return Route.parse_obj(data)
 
     async def get_integration_details(self, integration_id):
         url = f"{self.integrations_endpoint}/{integration_id}/"
         response = await self._get(url)
-        # ToDo: Add custom exceptions to handle errors
-        response.raise_for_status()
+        self._raise_for_status(response)
         data = response.json()
         return Integration.parse_obj(data)
 
     async def get_integration_api_key(self, integration_id):
         url = f"{self.integrations_endpoint}/{integration_id}/api-key/"
         response = await self._get(url)
-        # ToDo: Add custom exceptions to handle errors
-        response.raise_for_status()
+        self._raise_for_status(response)
         data = response.json()
         return data.get("api_key")
 
     async def get_traces(self, params: dict):
         url = f"{self.traces_endpoint}/"
         response = await self._get(url, params=params)
-        # ToDo: Add custom exceptions to handle errors
-        response.raise_for_status()
+        self._raise_for_status(response)
         data = response.json()["results"]
         return parse_obj_as(List[GundiTrace], data)
 
@@ -282,7 +281,6 @@ class GundiClient:
             url,
             data=data,
         )
-        # ToDo: Add custom exceptions to handle errors
-        response.raise_for_status()
+        self._raise_for_status(response)
         data = response.json()
         return IntegrationType.parse_obj(data)

--- a/gundi_client_v2/errors.py
+++ b/gundi_client_v2/errors.py
@@ -1,0 +1,29 @@
+import httpx
+
+
+class GundiClientError(Exception):
+    """Base exception for the Gundi client."""
+
+
+class AuthenticationError(GundiClientError):
+    """Raised when OAuth token retrieval or authentication fails."""
+
+
+class GundiAPIError(GundiClientError):
+    """Raised when the Gundi API returns a non-2xx response."""
+
+    def __init__(self, status_code: int, detail: str = ""):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"HTTP {status_code}: {detail}" if detail else f"HTTP {status_code}")
+
+
+def raise_for_status(response):
+    """Raise GundiAPIError for a non-2xx httpx response, preserving the original error."""
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        raise GundiAPIError(
+            status_code=e.response.status_code,
+            detail=e.response.text,
+        ) from e

--- a/gundi_client_v2/errors.py
+++ b/gundi_client_v2/errors.py
@@ -10,7 +10,7 @@ class AuthenticationError(GundiClientError):
 
 
 class GundiAPIError(GundiClientError):
-    """Raised when the Gundi API returns a non-2xx response."""
+    """Raised when the Gundi API returns a client or server error (4xx/5xx) response."""
 
     def __init__(self, status_code: int, detail: str = ""):
         self.status_code = status_code
@@ -19,7 +19,11 @@ class GundiAPIError(GundiClientError):
 
 
 def raise_for_status(response):
-    """Raise GundiAPIError for a non-2xx httpx response, preserving the original error."""
+    """Raise GundiAPIError for a 4xx/5xx httpx response, preserving the original error.
+
+    Mirrors httpx.Response.raise_for_status(), which raises only for client/server
+    error statuses (3xx redirects do not raise).
+    """
     try:
         response.raise_for_status()
     except httpx.HTTPStatusError as e:

--- a/tests/client/test_errors.py
+++ b/tests/client/test_errors.py
@@ -1,0 +1,46 @@
+import httpx
+import pytest
+import respx
+
+from gundi_client_v2 import errors
+from gundi_client_v2.client import GundiDataSenderClient
+
+
+@pytest.mark.asyncio
+async def test_get_raises_gundi_api_error_on_4xx(auth_token_response, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        integration_id = "11115b4f-88cd-49c4-a723-0ddff1f580c4"
+        url = f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
+        mock.get(url).respond(status_code=404, json={"detail": "Not found"})
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.get_integration_details(integration_id)
+        assert exc.value.status_code == 404
+        assert "Not found" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_data_sender_post_raises_gundi_api_error(
+    gundi_data_sender_client_v2, event_payload
+):
+    async with respx.mock as mock:
+        url = f"{gundi_data_sender_client_v2.sensors_api_endpoint}/events/"
+        mock.post(url).respond(status_code=500, json={"detail": "boom"})
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_data_sender_client_v2.post_events(data=[event_payload])
+        assert exc.value.status_code == 500
+        assert "boom" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_data_sender_update_raises_gundi_api_error(gundi_data_sender_client_v2):
+    async with respx.mock as mock:
+        event_id = "abebe106-3c50-446b-9c98-0b9b503fc900"
+        url = f"{gundi_data_sender_client_v2.sensors_api_endpoint}/events/{event_id}/"
+        mock.patch(url).respond(status_code=400, json={"detail": "bad update"})
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_data_sender_client_v2.update_event(event_id=event_id, data={"title": "x"})
+        assert exc.value.status_code == 400
+        assert "bad update" in exc.value.detail

--- a/tests/client/test_errors.py
+++ b/tests/client/test_errors.py
@@ -3,7 +3,6 @@ import pytest
 import respx
 
 from gundi_client_v2 import errors
-from gundi_client_v2.client import GundiDataSenderClient
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
PR 3/6. Stacked on the oauth-rename PR.

- Add `errors` module: `GundiClientError`, `AuthenticationError`, `GundiAPIError(status_code, detail)`
- Single `errors.raise_for_status()` helper maps `httpx.HTTPStatusError` -> `GundiAPIError`; routed through all `GundiClient` and `GundiDataSenderClient` API calls
- Export error classes from the package

## Test Plan
- [x] `pytest` — 17 passed (incl. 4xx GET, 500 POST, 400 PATCH error-mapping tests)