### PR TITLE
feat: add get_connections and paginated get_integrations

### DIFF
--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -9,7 +9,7 @@ from httpx import (
     Timeout,
 )
 from pydantic import parse_obj_as
-from typing import List
+from typing import AsyncGenerator, List
 from gundi_core.schemas import (
     OAuthToken,
 )
@@ -240,6 +240,20 @@ class GundiClient:
     def _raise_for_status(response):
         errors.raise_for_status(response)
 
+    @staticmethod
+    def _parse_list_response(data, model):
+        if isinstance(data, list):
+            return parse_obj_as(List[model], data)
+        if isinstance(data, dict) and "results" in data:
+            return parse_obj_as(List[model], data["results"])
+        return [model.parse_obj(data)]
+
+    async def get_connections(self, params: dict = None) -> List[Connection]:
+        url = f"{self.connections_endpoint}/"
+        response = await self._get(url, params=params)
+        self._raise_for_status(response)
+        return self._parse_list_response(response.json(), Connection)
+
     async def get_connection_details(self, integration_id):
         url = f"{self.connections_endpoint}/{integration_id}/"
         response = await self._get(url)
@@ -253,6 +267,20 @@ class GundiClient:
         self._raise_for_status(response)
         data = response.json()
         return Route.parse_obj(data)
+
+    async def get_integrations(self, params: dict = None) -> AsyncGenerator[Integration, None]:
+        url = f"{self.integrations_endpoint}/"
+        while url:
+            response = await self._get(url, params=params)
+            self._raise_for_status(response)
+            data = response.json()
+            params = None  # the `next` URL already carries the query string
+            for item in self._parse_list_response(data, Integration):
+                yield item
+            if isinstance(data, dict) and "results" in data:
+                url = data.get("next") or ""
+            else:
+                return
 
     async def get_integration_details(self, integration_id):
         url = f"{self.integrations_endpoint}/{integration_id}/"

--- a/tests/client/test_read_methods.py
+++ b/tests/client/test_read_methods.py
@@ -1,0 +1,94 @@
+import httpx
+import pytest
+import respx
+from gundi_core.schemas.v2 import Connection, Integration
+
+from gundi_client_v2.client import GundiClient
+
+
+def _integration(idx):
+    return {
+        "id": f"338225f3-91f9-4fe1-b013-35322900000{idx}",
+        "name": f"Integration {idx}",
+        "base_url": "https://example.org",
+        "enabled": True,
+        "type": {"id": "45c66a61-71e4-4664-a7f2-30d465f87aa6", "name": "EarthRanger",
+                 "value": "earth_ranger", "description": "", "actions": []},
+        "owner": {"id": "e2d1b0fc-69fe-408b-afc5-7f54872730c0", "name": "Org", "description": ""},
+        "configurations": [], "additional": {}, "default_route": None, "status": "healthy",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_connections_parses_bare_list(auth_token_response, connection_details, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.connections_endpoint}/").respond(
+            status_code=httpx.codes.OK, json=[connection_details]
+        )
+        result = await gundi_client_v2.get_connections()
+        assert len(result) == 1
+        assert isinstance(result[0], Connection)
+
+
+@pytest.mark.asyncio
+async def test_get_connections_parses_results_envelope(auth_token_response, connection_details, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.connections_endpoint}/").respond(
+            status_code=httpx.codes.OK, json={"results": [connection_details], "next": None}
+        )
+        result = await gundi_client_v2.get_connections()
+        assert len(result) == 1
+        assert isinstance(result[0], Connection)
+
+
+@pytest.mark.asyncio
+async def test_get_integrations_follows_pagination(auth_token_response, gundi_client_v2):
+    page2 = f"{gundi_client_v2.integrations_endpoint}/?cursor=abc"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        # Register the more-specific page2 route first so respx matches it before the base route
+        mock.get(page2).respond(
+            status_code=httpx.codes.OK, json={"results": [_integration(2)], "next": None}
+        )
+        mock.get(f"{gundi_client_v2.integrations_endpoint}/").respond(
+            status_code=httpx.codes.OK, json={"results": [_integration(1)], "next": page2}
+        )
+        collected = [i async for i in gundi_client_v2.get_integrations()]
+        assert [i.name for i in collected] == ["Integration 1", "Integration 2"]
+        assert all(isinstance(i, Integration) for i in collected)
+
+
+@pytest.mark.asyncio
+async def test_get_integrations_single_page_list(auth_token_response, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.integrations_endpoint}/").respond(
+            status_code=httpx.codes.OK, json=[_integration(1)]
+        )
+        collected = [i async for i in gundi_client_v2.get_integrations()]
+        assert len(collected) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_integrations_single_object_response(auth_token_response, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.integrations_endpoint}/").respond(
+            status_code=httpx.codes.OK, json=_integration(1)
+        )
+        collected = [i async for i in gundi_client_v2.get_integrations()]
+        assert len(collected) == 1
+        assert isinstance(collected[0], Integration)
+
+
+@pytest.mark.asyncio
+async def test_get_integrations_empty_results(auth_token_response, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.integrations_endpoint}/").respond(
+            status_code=httpx.codes.OK, json={"results": [], "next": None}
+        )
+        collected = [i async for i in gundi_client_v2.get_integrations()]
+        assert collected == []

--- a/tests/client/test_read_methods.py
+++ b/tests/client/test_read_methods.py
@@ -3,8 +3,6 @@ import pytest
 import respx
 from gundi_core.schemas.v2 import Connection, Integration
 
-from gundi_client_v2.client import GundiClient
-
 
 def _integration(idx):
     return {


### PR DESCRIPTION
## Summary
PR 4/6. Stacked on the errors PR.

- `get_connections()` -> `List[Connection]` (handles bare list or DRF `{results}` envelope)
- `get_integrations()` async generator following DRF `next`-link pagination
- Shared `_parse_list_response` helper (reused by both)

## Test Plan
- [x] `pytest` — 23 passed (bare-list, results-envelope, two-page pagination, single-page, single-object, empty-results)