### PR TITLE
feat: OAuth2 password grant with refresh-token flow and error parsing

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.1"
+__version__ = "2.5.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/auth.py
+++ b/gundi_client_v2/auth.py
@@ -24,13 +24,18 @@ def _extract_oauth_error(response):
     return f"Token request failed: HTTP {status} ({error})"
 
 
-async def _token_request(session, oauth_token_url, payload) -> OAuthToken:
+async def _post_token(session, oauth_token_url, payload) -> dict:
+    """POST to the token endpoint; raise AuthenticationError on non-2xx."""
     response = await session.post(oauth_token_url, data=payload)
     try:
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         raise AuthenticationError(_extract_oauth_error(e.response)) from e
-    return OAuthToken.parse_obj(response.json())
+    return response.json()
+
+
+async def _token_request(session, oauth_token_url, payload) -> OAuthToken:
+    return OAuthToken.parse_obj(await _post_token(session, oauth_token_url, payload))
 
 
 async def get_access_token(session, oauth_token_url, client_id, client_secret, audience=None, scope="openid"):
@@ -62,7 +67,24 @@ async def get_access_token_password_grant(session, oauth_token_url, client_id, u
     return await _token_request(session, oauth_token_url, payload)
 
 
-async def refresh_access_token(session, oauth_token_url, client_id, refresh_token, client_secret=None, scope="openid"):
+async def refresh_access_token(
+    session,
+    oauth_token_url,
+    client_id,
+    refresh_token,
+    fallback: OAuthToken,
+    client_secret=None,
+    scope="openid",
+):
+    """Exchange a refresh_token for a new access token (RFC 6749 §6).
+
+    Returns a tuple ``(token, refresh_rotated)``. ``refresh_rotated`` is True
+    when the IdP issued a new refresh_token in the response and False when it
+    omitted one (RFC 6749 §6 makes the new refresh_token OPTIONAL). When the
+    server omits it the cached refresh_token/refresh_expires_in from
+    ``fallback`` are reused so the caller can keep its existing refresh
+    metadata and the user's credentials are not re-transmitted.
+    """
     logger.debug(f"refresh_access_token from {oauth_token_url} using client_id: {client_id}")
     payload = {
         "client_id": client_id,
@@ -72,4 +94,9 @@ async def refresh_access_token(session, oauth_token_url, client_id, refresh_toke
     }
     if client_secret:
         payload["client_secret"] = client_secret
-    return await _token_request(session, oauth_token_url, payload)
+    body = await _post_token(session, oauth_token_url, payload)
+    refresh_rotated = "refresh_token" in body
+    # Backfill missing refresh fields before constructing OAuthToken (which requires them).
+    body.setdefault("refresh_token", fallback.refresh_token)
+    body.setdefault("refresh_expires_in", fallback.refresh_expires_in)
+    return OAuthToken.parse_obj(body), refresh_rotated

--- a/gundi_client_v2/auth.py
+++ b/gundi_client_v2/auth.py
@@ -17,6 +17,11 @@ def _extract_oauth_error(response):
         body = response.json()
     except ValueError:
         return f"Token request failed: HTTP {status}"
+    # RFC 6749 §5.2 errors are JSON objects, but a malformed server could return
+    # a non-object (string, list, number, null). Fall back to a status-only message
+    # so this helper cannot raise AttributeError out of _post_token's except path.
+    if not isinstance(body, dict):
+        return f"Token request failed: HTTP {status}"
     error = body.get("error", "unknown_error")
     description = body.get("error_description")
     if description:

--- a/gundi_client_v2/auth.py
+++ b/gundi_client_v2/auth.py
@@ -1,23 +1,75 @@
 import logging
-from gundi_core.schemas import (
-    OAuthToken,
-)
+
+import httpx
+from gundi_core.schemas import OAuthToken
+
+from .errors import AuthenticationError
 
 logger = logging.getLogger(__name__)
 
+UMA_TICKET_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:uma-ticket"
 
-async def get_access_token(session, oauth_token_url, client_id, client_secret, audience):
-    logger.debug(
-        f"get_access_token from {oauth_token_url} using client_id: {client_id}"
-    )
+
+def _extract_oauth_error(response):
+    """Build a detail string from an RFC 6749 §5.2 token-error response."""
+    status = response.status_code
+    try:
+        body = response.json()
+    except ValueError:
+        return f"Token request failed: HTTP {status}"
+    error = body.get("error", "unknown_error")
+    description = body.get("error_description")
+    if description:
+        return f"Token request failed: HTTP {status} ({error}: {description})"
+    return f"Token request failed: HTTP {status} ({error})"
+
+
+async def _token_request(session, oauth_token_url, payload) -> OAuthToken:
+    response = await session.post(oauth_token_url, data=payload)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        raise AuthenticationError(_extract_oauth_error(e.response)) from e
+    return OAuthToken.parse_obj(response.json())
+
+
+async def get_access_token(session, oauth_token_url, client_id, client_secret, audience=None, scope="openid"):
+    logger.debug(f"get_access_token from {oauth_token_url} using client_id: {client_id}")
     payload = {
         "client_id": client_id,
         "client_secret": client_secret,
-        "audience": audience,
-        "grant_type": "urn:ietf:params:oauth:grant-type:uma-ticket",
-        "scope": "openid",
+        "grant_type": UMA_TICKET_GRANT_TYPE,
+        "scope": scope,
     }
-    response = await session.post(oauth_token_url, data=payload)
-    response.raise_for_status()
-    token = response.json()
-    return OAuthToken.parse_obj(token)
+    if audience:
+        payload["audience"] = audience
+    return await _token_request(session, oauth_token_url, payload)
+
+
+# NOTE: The Resource Owner Password Credentials (ROPC) grant is discouraged by OAuth 2.1
+# (RFC 9700). It is supported here intentionally, for public clients that require it.
+async def get_access_token_password_grant(session, oauth_token_url, client_id, username, password, audience=None, scope="openid"):
+    logger.debug(f"get_access_token (password grant) from {oauth_token_url} for user: {username}")
+    payload = {
+        "client_id": client_id,
+        "username": username,
+        "password": password,
+        "grant_type": "password",
+        "scope": scope,
+    }
+    if audience:
+        payload["audience"] = audience
+    return await _token_request(session, oauth_token_url, payload)
+
+
+async def refresh_access_token(session, oauth_token_url, client_id, refresh_token, client_secret=None, scope="openid"):
+    logger.debug(f"refresh_access_token from {oauth_token_url} using client_id: {client_id}")
+    payload = {
+        "client_id": client_id,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "scope": scope,
+    }
+    if client_secret:
+        payload["client_secret"] = client_secret
+    return await _token_request(session, oauth_token_url, payload)

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -142,11 +142,15 @@ class GundiClient:
                                     kwargs.get("keycloak_client_id", settings.OAUTH_CLIENT_ID))
         self.client_secret = kwargs.get("oauth_client_secret",
                                         kwargs.get("keycloak_client_secret", settings.OAUTH_CLIENT_SECRET))
+        self.username = kwargs.get("username", settings.GUNDI_USERNAME)
+        self.password = kwargs.get("password", settings.GUNDI_PASSWORD)
         self.oauth_token_url = kwargs.get("oauth_token_url", settings.OAUTH_TOKEN_URL)
         self.audience = kwargs.get("oauth_audience",
                                    kwargs.get("keycloak_audience", settings.OAUTH_AUDIENCE))
+        self.scope = kwargs.get("oauth_scope", settings.OAUTH_SCOPE)
         self.cached_token = None
         self.cached_token_expires_at = datetime.min.replace(tzinfo=timezone.utc)
+        self.cached_token_refresh_expires_at = datetime.min.replace(tzinfo=timezone.utc)
 
         # Retries and timeouts settings
         self.max_retries = kwargs.get('max_http_retries', self.DEFAULT_CONNECTION_RETRIES)
@@ -212,18 +216,70 @@ class GundiClient:
         return response
 
     async def _refresh_token(self):
-        token = await auth.get_access_token(
-            session=self._session,
-            oauth_token_url=self.oauth_token_url,
-            client_id=self.client_id,
-            client_secret=self.client_secret,
-            audience=self.audience
-        )
-        self.cached_token_expires_at = datetime.now(tz=timezone.utc) + timedelta(
-            seconds=token.expires_in - 15
-        )  # fudge factor
-        self.cached_token = token
+        now = datetime.now(tz=timezone.utc)
+        # 1. Prefer the refresh-token grant when we hold a live refresh token.
+        if (
+            self.cached_token
+            and self.cached_token.refresh_token
+            and self.cached_token_refresh_expires_at > now
+        ):
+            try:
+                token = await auth.refresh_access_token(
+                    session=self._session,
+                    oauth_token_url=self.oauth_token_url,
+                    client_id=self.client_id,
+                    refresh_token=self.cached_token.refresh_token,
+                    # Public/password clients must not send a secret on refresh.
+                    client_secret=None if (self.username and self.password) else self.client_secret,
+                    scope=self.scope,
+                )
+                self._store_token(token)
+                return token
+            except errors.AuthenticationError:
+                logger.info("Refresh-token grant failed; falling back to full re-authentication.")
+                self.cached_token_refresh_expires_at = datetime.min.replace(tzinfo=timezone.utc)
+
+        # 2. Full authentication. Password grant wins when user credentials are present.
+        if self.username and self.password:
+            logger.debug("Authenticating via password grant.")
+            token = await auth.get_access_token_password_grant(
+                session=self._session,
+                oauth_token_url=self.oauth_token_url,
+                client_id=self.client_id,
+                username=self.username,
+                password=self.password,
+                audience=self.audience,
+                scope=self.scope,
+            )
+        elif self.client_id and self.client_secret:
+            logger.debug("Authenticating via client-credentials (uma-ticket) grant.")
+            token = await auth.get_access_token(
+                session=self._session,
+                oauth_token_url=self.oauth_token_url,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+                audience=self.audience,
+                scope=self.scope,
+            )
+        else:
+            raise errors.AuthenticationError(
+                "No credentials configured. Provide username/password or client_id/client_secret."
+            )
+        self._store_token(token)
         return token
+
+    def _store_token(self, token):
+        # OAuthToken (gundi-core) always carries access + refresh fields on a successful parse.
+        now = datetime.now(tz=timezone.utc)
+        self.cached_token = token
+        self.cached_token_expires_at = now + timedelta(seconds=self._expiry_with_buffer(token.expires_in))
+        self.cached_token_refresh_expires_at = now + timedelta(seconds=self._expiry_with_buffer(token.refresh_expires_in))
+
+    @staticmethod
+    def _expiry_with_buffer(lifetime_seconds, buffer_seconds=15):
+        # Subtract a clock-skew buffer, but never more than half the lifetime, so a short-lived
+        # token is not treated as already expired (which would re-authenticate on every call).
+        return max(lifetime_seconds - buffer_seconds, lifetime_seconds // 2)
 
     async def get_access_token(self, force_refresh_token=False) -> OAuthToken:
         if force_refresh_token or not self.cached_token or self.cached_token_expires_at < datetime.now(tz=timezone.utc):

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -224,23 +224,27 @@ class GundiClient:
             and self.cached_token_refresh_expires_at > now
         ):
             try:
-                token = await auth.refresh_access_token(
+                token, refresh_rotated = await auth.refresh_access_token(
                     session=self._session,
                     oauth_token_url=self.oauth_token_url,
                     client_id=self.client_id,
                     refresh_token=self.cached_token.refresh_token,
+                    fallback=self.cached_token,
                     # Public/password clients must not send a secret on refresh.
                     client_secret=None if (self.username and self.password) else self.client_secret,
                     scope=self.scope,
                 )
-                self._store_token(token)
+                self._store_token(token, refresh_rotated=refresh_rotated)
                 return token
             except errors.AuthenticationError:
                 logger.info("Refresh-token grant failed; falling back to full re-authentication.")
                 self.cached_token_refresh_expires_at = datetime.min.replace(tzinfo=timezone.utc)
 
         # 2. Full authentication. Password grant wins when user credentials are present.
-        if self.username and self.password:
+        # A client_id is required for every grant we support, so guard the password
+        # branch on it too — otherwise we'd send a half-formed request and let the IdP
+        # reject it remotely instead of failing locally with a clear configuration error.
+        if self.username and self.password and self.client_id:
             logger.debug("Authenticating via password grant.")
             token = await auth.get_access_token_password_grant(
                 session=self._session,
@@ -263,17 +267,23 @@ class GundiClient:
             )
         else:
             raise errors.AuthenticationError(
-                "No credentials configured. Provide username/password or client_id/client_secret."
+                "No credentials configured. Provide a client_id with either "
+                "username/password (public client) or client_secret (confidential client)."
             )
         self._store_token(token)
         return token
 
-    def _store_token(self, token):
+    def _store_token(self, token, *, refresh_rotated=True):
         # OAuthToken (gundi-core) always carries access + refresh fields on a successful parse.
+        # ``refresh_rotated`` is False only when this token came from a refresh-grant response
+        # that omitted a new refresh_token (RFC 6749 §6) — in that case we preserve the
+        # existing cached_token_refresh_expires_at because the cached refresh token is still
+        # valid for its original lifetime.
         now = datetime.now(tz=timezone.utc)
         self.cached_token = token
         self.cached_token_expires_at = now + timedelta(seconds=self._expiry_with_buffer(token.expires_in))
-        self.cached_token_refresh_expires_at = now + timedelta(seconds=self._expiry_with_buffer(token.refresh_expires_in))
+        if refresh_rotated:
+            self.cached_token_refresh_expires_at = now + timedelta(seconds=self._expiry_with_buffer(token.refresh_expires_in))
 
     @staticmethod
     def _expiry_with_buffer(lifetime_seconds, buffer_seconds=15):

--- a/gundi_client_v2/settings.py
+++ b/gundi_client_v2/settings.py
@@ -17,6 +17,7 @@ OAUTH_TOKEN_URL = f"{OAUTH_ISSUER}/protocol/openid-connect/token" if OAUTH_ISSUE
 OAUTH_CLIENT_ID = env.str("OAUTH_CLIENT_ID", env.str("KEYCLOAK_CLIENT_ID", None))
 OAUTH_CLIENT_SECRET = env.str("OAUTH_CLIENT_SECRET", env.str("KEYCLOAK_CLIENT_SECRET", None))
 OAUTH_AUDIENCE = env.str("OAUTH_AUDIENCE", env.str("KEYCLOAK_AUDIENCE", None))
+OAUTH_SCOPE = env.str("OAUTH_SCOPE", "openid")
 
 # Backward-compatible aliases for the pre-rename setting names. Code importing
 # gundi_client_v2.settings.KEYCLOAK_* keeps working; these mirror the OAUTH_* values.
@@ -29,5 +30,7 @@ GUNDI_API_BASE_URL = env.str("GUNDI_API_BASE_URL", None)
 GUNDI_API_SSL_VERIFY = env.bool("GUNDI_API_SSL_VERIFY", True)
 
 SENSORS_API_BASE_URL = env.str("SENSORS_API_BASE_URL", None)
+GUNDI_USERNAME = env.str("GUNDI_USERNAME", None)
+GUNDI_PASSWORD = env.str("GUNDI_PASSWORD", None)
 
 LOG_LEVEL = env.log_level("LOG_LEVEL", "INFO")

--- a/tests/client/test_password_grant.py
+++ b/tests/client/test_password_grant.py
@@ -1,0 +1,195 @@
+import httpx
+import pytest
+import respx
+from datetime import datetime, timezone
+from urllib.parse import parse_qs
+
+from gundi_client_v2 import errors
+from gundi_client_v2.client import GundiClient
+
+TOKEN_URL = "https://fakeauth.com/realms/dev/protocol/openid-connect/token"
+
+
+def _public_password_client(**overrides):
+    kwargs = dict(
+        oauth_token_url=TOKEN_URL,
+        oauth_client_id="public-client",
+        username="alice",
+        password="s3cret",
+        base_url="https://api.fakeportal.com",
+    )
+    kwargs.update(overrides)
+    client = GundiClient(**kwargs)
+    if "oauth_client_secret" not in overrides:
+        client.client_secret = None
+    return client
+
+
+def _confidential_client(**overrides):
+    kwargs = dict(
+        oauth_token_url=TOKEN_URL,
+        oauth_client_id="confidential-client",
+        oauth_client_secret="shhh",
+        base_url="https://api.fakeportal.com",
+    )
+    kwargs.update(overrides)
+    client = GundiClient(**kwargs)
+    client.username = None
+    client.password = None
+    return client
+
+
+def _body(route, index=-1):
+    return parse_qs(route.calls[index].request.content.decode())
+
+
+@pytest.mark.asyncio
+async def test_password_grant_payload(auth_token_response):
+    client = _public_password_client()
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        await client.get_access_token()
+        params = _body(route)
+        assert params["grant_type"] == ["password"]
+        assert params["username"] == ["alice"]
+        assert params["password"] == ["s3cret"]
+        assert params["scope"] == ["openid"]
+        assert "client_secret" not in params
+
+
+@pytest.mark.asyncio
+async def test_audience_omitted_when_unset(auth_token_response):
+    client = _confidential_client()
+    client.audience = None
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        await client.get_access_token()
+        assert "audience" not in _body(route)
+
+
+@pytest.mark.asyncio
+async def test_audience_included_when_set(auth_token_response):
+    client = _confidential_client(oauth_audience="my-portal")
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        await client.get_access_token()
+        assert _body(route)["audience"] == ["my-portal"]
+
+
+@pytest.mark.asyncio
+async def test_scope_override(auth_token_response):
+    client = _confidential_client(oauth_scope="openid profile")
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        await client.get_access_token()
+        assert _body(route)["scope"] == ["openid profile"]
+
+
+@pytest.mark.asyncio
+async def test_error_body_surfaced(auth_token_response):
+    client = _confidential_client()
+    async with respx.mock as mock:
+        mock.post(TOKEN_URL).respond(
+            status_code=401,
+            json={"error": "invalid_client", "error_description": "Invalid client credentials"},
+        )
+        with pytest.raises(errors.AuthenticationError) as exc:
+            await client.get_access_token()
+        assert "invalid_client" in str(exc.value)
+        assert "Invalid client credentials" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_grant_used_and_password_not_resent(auth_token_response):
+    client = _public_password_client()
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        await client.get_access_token()
+        await client.get_access_token(force_refresh_token=True)
+        assert route.call_count == 2
+        assert _body(route, 0)["grant_type"] == ["password"]
+        second = _body(route, 1)
+        assert second["grant_type"] == ["refresh_token"]
+        assert "refresh_token" in second
+        assert "password" not in second
+        assert "client_secret" not in second
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_falls_back_to_full_auth(auth_token_response):
+    client = _public_password_client()
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL)
+        route.side_effect = [
+            httpx.Response(httpx.codes.OK, json=auth_token_response),
+            httpx.Response(400, json={"error": "invalid_grant", "error_description": "expired"}),
+            httpx.Response(httpx.codes.OK, json=auth_token_response),
+        ]
+        await client.get_access_token()
+        await client.get_access_token(force_refresh_token=True)
+        assert route.call_count == 3
+        assert _body(route, 1)["grant_type"] == ["refresh_token"]
+        assert _body(route, 2)["grant_type"] == ["password"]
+
+
+@pytest.mark.asyncio
+async def test_no_credentials_raises():
+    client = GundiClient(oauth_token_url=TOKEN_URL, base_url="https://api.fakeportal.com")
+    client.client_id = None
+    client.client_secret = None
+    client.username = None
+    client.password = None
+    with pytest.raises(errors.AuthenticationError):
+        await client.get_access_token()
+
+
+@pytest.mark.asyncio
+async def test_full_auth_when_token_and_refresh_expired(auth_token_response):
+    client = _public_password_client()
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        await client.get_access_token()  # initial password grant, caches a refresh token
+        # Simulate BOTH the access token and the refresh token having expired:
+        client.cached_token_expires_at = datetime.min.replace(tzinfo=timezone.utc)
+        client.cached_token_refresh_expires_at = datetime.min.replace(tzinfo=timezone.utc)
+        await client.get_access_token()  # must skip refresh and do a full password grant
+        assert route.call_count == 2
+        assert _body(route, 1)["grant_type"] == ["password"]
+
+
+@pytest.mark.asyncio
+async def test_short_lived_token_not_immediately_expired(auth_token_response):
+    short = dict(auth_token_response)
+    short["expires_in"] = 10
+    short["refresh_expires_in"] = 10
+    client = _public_password_client()
+    async with respx.mock as mock:
+        mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=short)
+        await client.get_access_token()
+        # With the half-life clamp, a 10s token must NOT be treated as already expired.
+        assert client.cached_token_expires_at > datetime.now(tz=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_confidential_refresh_sends_client_secret(auth_token_response):
+    # A confidential (uma-ticket) client MUST send its client_secret on the refresh grant.
+    client = _confidential_client()
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        await client.get_access_token()                          # initial uma-ticket grant
+        await client.get_access_token(force_refresh_token=True)  # refresh grant
+        assert route.call_count == 2
+        second = _body(route, 1)
+        assert second["grant_type"] == ["refresh_token"]
+        assert second["client_secret"] == ["shhh"]
+
+
+@pytest.mark.asyncio
+async def test_error_body_non_json_falls_back_to_status():
+    # A non-JSON error body must still produce an AuthenticationError carrying the status code.
+    client = _confidential_client()
+    async with respx.mock as mock:
+        mock.post(TOKEN_URL).respond(status_code=503, text="Service Unavailable")
+        with pytest.raises(errors.AuthenticationError) as exc:
+            await client.get_access_token()
+        assert "503" in str(exc.value)

--- a/tests/client/test_password_grant.py
+++ b/tests/client/test_password_grant.py
@@ -196,6 +196,19 @@ async def test_error_body_non_json_falls_back_to_status():
 
 
 @pytest.mark.asyncio
+async def test_error_body_non_object_json_falls_back_to_status():
+    # Valid JSON but not an object (string/list/null) must NOT escape as AttributeError —
+    # the helper must still produce an AuthenticationError carrying the status code so the
+    # refresh-fallback path in _refresh_token continues to work.
+    client = _confidential_client()
+    async with respx.mock as mock:
+        mock.post(TOKEN_URL).respond(status_code=400, json=["invalid_grant"])
+        with pytest.raises(errors.AuthenticationError) as exc:
+            await client.get_access_token()
+        assert "400" in str(exc.value)
+
+
+@pytest.mark.asyncio
 async def test_refresh_preserves_cached_refresh_token_when_omitted(auth_token_response):
     # RFC 6749 §6: the new refresh_token is OPTIONAL on a refresh response. When the
     # IdP omits it, the cached refresh_token and its expiry must be preserved (and the

--- a/tests/client/test_password_grant.py
+++ b/tests/client/test_password_grant.py
@@ -193,3 +193,55 @@ async def test_error_body_non_json_falls_back_to_status():
         with pytest.raises(errors.AuthenticationError) as exc:
             await client.get_access_token()
         assert "503" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_refresh_preserves_cached_refresh_token_when_omitted(auth_token_response):
+    # RFC 6749 §6: the new refresh_token is OPTIONAL on a refresh response. When the
+    # IdP omits it, the cached refresh_token and its expiry must be preserved (and the
+    # user's password must NOT be re-sent).
+    client = _public_password_client()
+    partial_refresh_response = {
+        "access_token": "new-access-token-value",
+        "expires_in": auth_token_response["expires_in"],
+        "token_type": "Bearer",
+    }
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL)
+        route.side_effect = [
+            httpx.Response(httpx.codes.OK, json=auth_token_response),       # initial password grant
+            httpx.Response(httpx.codes.OK, json=partial_refresh_response),  # refresh: no refresh_token
+        ]
+        await client.get_access_token()
+        original_refresh_token = client.cached_token.refresh_token
+        original_refresh_expires_at = client.cached_token_refresh_expires_at
+
+        await client.get_access_token(force_refresh_token=True)
+
+        # The refresh grant fired exactly once — no silent fall-through to a second full auth.
+        assert route.call_count == 2
+        assert _body(route, 1)["grant_type"] == ["refresh_token"]
+        # The user's password was NOT re-sent on the refresh.
+        assert "password" not in _body(route, 1)
+        # Access token rotated to the new value from the partial response.
+        assert client.cached_token.access_token == "new-access-token-value"
+        # Cached refresh token + its expiry are preserved across the partial refresh.
+        assert client.cached_token.refresh_token == original_refresh_token
+        assert client.cached_token_refresh_expires_at == original_refresh_expires_at
+
+
+@pytest.mark.asyncio
+async def test_password_grant_requires_client_id():
+    # username/password without a client_id must fail locally with a clear configuration
+    # error rather than firing a half-formed token request the IdP would reject.
+    client = GundiClient(
+        oauth_token_url=TOKEN_URL,
+        base_url="https://api.fakeportal.com",
+        username="alice",
+        password="s3cret",
+    )
+    client.client_id = None
+    client.client_secret = None
+    with pytest.raises(errors.AuthenticationError) as exc:
+        await client.get_access_token()
+    assert "client_id" in str(exc.value)


### PR DESCRIPTION
## Summary
PR 5/6 — the auth feature. Stacked on the read-methods PR.

- OAuth2 Resource-Owner-Password-Credentials grant for **public** clients (no client_secret)
- Refresh-token grant flow (RFC 6749 §6): a user's password is sent once, then only the refresh token circulates; failed refresh falls back to full re-auth
- Parse RFC 6749 §5.2 `{error, error_description}` bodies into `AuthenticationError`
- Configurable `scope`; `audience` sent only when set; expiry skew clamped to half the token lifetime
- Credential precedence: password grant wins when user creds present; confidential clients keep the uma-ticket grant
- Version bump to 2.5.0

## Test Plan
- [x] `pytest` — 35 passed (payload shape, audience on/off, scope, error-body incl. non-JSON, refresh-reuse, refresh-fallback, confidential-refresh-secret, expiry clamp, no-credentials)