### PR TITLE
docs: usage docs and examples for oauth/password-grant auth and read methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ client = GundiClient(
 
 ```python
 import asyncio
+import os
 from gundi_client_v2 import GundiClient, GundiDataSenderClient
 
 async def main():
@@ -65,7 +66,10 @@ async def main():
         )
 
     # 3. Use the API key to send data
-    sender = GundiDataSenderClient(integration_api_key=api_key)
+    sender = GundiDataSenderClient(
+        integration_api_key=api_key,
+        sensors_api_base_url=os.environ["SENSORS_API_BASE_URL"],  # or pass the URL directly
+    )
     await sender.post_events(data=[
         {
             "title": "Animal Detected",
@@ -214,14 +218,18 @@ if __name__ == "__main__":
 
 ## Usage: GundiDataSenderClient
 
-Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials.
+Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials. `sensors_api_base_url` is required — you can set it via the `SENSORS_API_BASE_URL` environment variable (as the example script does) or pass it directly.
 
 ```python
 import asyncio
+import os
 from gundi_client_v2 import GundiDataSenderClient
 
 async def main():
-    sender = GundiDataSenderClient(integration_api_key="your-api-key")
+    sender = GundiDataSenderClient(
+        integration_api_key="your-api-key",
+        sensors_api_base_url=os.environ["SENSORS_API_BASE_URL"],  # or pass the URL directly
+    )
 
     # Post observations
     await sender.post_observations(data=[

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Set your credentials via environment variables (see [Configuration](#configuration)) or pass them directly:
+Configure the client via environment variables (see [Configuration](#configuration)) or pass values directly. The Quick Start snippet needs more than credentials at runtime — at minimum a `base_url` / `GUNDI_API_BASE_URL`, an `OAUTH_CLIENT_ID`, and either an `OAUTH_ISSUER` or `oauth_token_url`. Example with kwargs:
 
 ```python
 client = GundiClient(
@@ -92,8 +92,7 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `GUNDI_PASSWORD` | Your Gundi password — required for password grant | — |
 | `OAUTH_CLIENT_ID` | OAuth client ID | — |
 | `OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
-| `OAUTH_ISSUER` | OAuth issuer base URL; token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. **Do not include a trailing slash** — the value is not stripped and a trailing slash will produce a double-slash in the derived URL. | — |
-| `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. Takes precedence over the value derived from `OAUTH_ISSUER` when set explicitly in the environment. | — |
+| `OAUTH_ISSUER` | OAuth issuer base URL; the token URL is derived from it as `{OAUTH_ISSUER}/protocol/openid-connect/token`. **Do not include a trailing slash** — the value is not stripped and a trailing slash will produce a double-slash in the derived URL. There is no `OAUTH_TOKEN_URL` env var; use the `oauth_token_url` kwarg if you need to override the derivation. | — |
 | `OAUTH_AUDIENCE` | OAuth audience | — |
 | `OAUTH_SCOPE` | OAuth scope | `openid` |
 | `GUNDI_API_BASE_URL` | Gundi API base URL | — |
@@ -112,7 +111,7 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `password` | `GUNDI_PASSWORD` | Gundi password |
 | `oauth_client_id` | `OAUTH_CLIENT_ID` | OAuth client ID |
 | `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | OAuth client secret |
-| `oauth_token_url` | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL |
+| `oauth_token_url` | — (derived from `OAUTH_ISSUER`) | Full OAuth token endpoint URL. No direct env-var counterpart — set `OAUTH_ISSUER` to have the token URL derived, or pass this kwarg to override. |
 | `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience |
 | `oauth_scope` | `OAUTH_SCOPE` | OAuth scope |
 | `max_http_retries` | — | Max HTTP retries (default `5`) |

--- a/README.md
+++ b/README.md
@@ -15,13 +15,18 @@ pip install gundi-client-v2
 ## Quick Start
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient
 
-async with GundiClient() as client:
-    connection = await client.get_connection_details(
-        integration_id="your-integration-uuid"
-    )
-    print(connection.provider.name)
+async def main():
+    async with GundiClient() as client:
+        connection = await client.get_connection_details(
+            integration_id="your-integration-uuid"
+        )
+        print(connection.provider.name)
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 Set your credentials via environment variables (see [Configuration](#configuration)) or pass them directly:
@@ -40,62 +45,88 @@ client = GundiClient(
 ### End-to-End: List, Get Key, Send Data
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient, GundiDataSenderClient
 
-async with GundiClient() as client:
-    # 1. List integrations and find yours by name
-    my_integration = None
-    async for i in client.get_integrations():
-        if i.name == "My Integration":
-            my_integration = i
-            break
+async def main():
+    async with GundiClient() as client:
+        # 1. List integrations and find yours by name
+        my_integration = None
+        async for i in client.get_integrations():
+            if i.name == "My Integration":
+                my_integration = i
+                break
+        if my_integration is None:
+            raise RuntimeError("Integration 'My Integration' not found")
 
-    # 2. Get the API key for that integration
-    api_key = await client.get_integration_api_key(
-        integration_id=str(my_integration.id)
-    )
+        # 2. Get the API key for that integration
+        api_key = await client.get_integration_api_key(
+            integration_id=str(my_integration.id)
+        )
 
-# 3. Use the API key to send data
-sender = GundiDataSenderClient(integration_api_key=api_key)
-await sender.post_events(data=[
-    {
-        "title": "Animal Detected",
-        "event_type": "wildlife_sighting_rep",
-        "recorded_at": "2024-01-15T10:30:00Z",
-        "location": {"lat": -1.286, "lon": 36.817},
-        "event_details": {"species": "lion"},
-    }
-])
+    # 3. Use the API key to send data
+    sender = GundiDataSenderClient(integration_api_key=api_key)
+    await sender.post_events(data=[
+        {
+            "title": "Animal Detected",
+            "event_type": "wildlife_sighting_rep",
+            "recorded_at": "2024-01-15T10:30:00Z",
+            "location": {"lat": -1.286, "lon": 36.817},
+            "event_details": {"species": "lion"},
+        }
+    ])
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Configuration
 
-All settings can be provided as environment variables or keyword arguments to the client constructor.
+Settings can be provided as **environment variables** or **constructor keyword arguments**. The two namespaces differ in several places — see the tables below.
 
-### Developer Authentication
+### Environment variables
 
-| Variable | Description | Required |
+| Env var | Description | Default |
 |---|---|---|
-| `GUNDI_USERNAME` | Your Gundi username (email) | Yes (for password auth) |
-| `GUNDI_PASSWORD` | Your Gundi password | Yes (for password auth) |
-
-### Service Authentication
-
-| Variable | Description | Required |
-|---|---|---|
-| `OAUTH_CLIENT_ID` | OAuth client ID | Yes |
-| `OAUTH_CLIENT_SECRET` | OAuth client secret | Yes (for client credentials auth) |
-
-### Common
-
-| Variable | Description | Default |
-|---|---|---|
-| `OAUTH_ISSUER` | OAuth issuer URL (token URL is derived as `{issuer}/protocol/openid-connect/token`) | — |
+| `GUNDI_USERNAME` | Your Gundi username (email) — required for password grant | — |
+| `GUNDI_PASSWORD` | Your Gundi password — required for password grant | — |
+| `OAUTH_CLIENT_ID` | OAuth client ID | — |
+| `OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
+| `OAUTH_ISSUER` | OAuth issuer base URL; token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. **Do not include a trailing slash** — the value is not stripped and a trailing slash will produce a double-slash in the derived URL. | — |
+| `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. Takes precedence over the value derived from `OAUTH_ISSUER` when set explicitly in the environment. | — |
 | `OAUTH_AUDIENCE` | OAuth audience | — |
+| `OAUTH_SCOPE` | OAuth scope | `openid` |
 | `GUNDI_API_BASE_URL` | Gundi API base URL | — |
-| `SENSORS_API_BASE_URL` | Sensors/routing API base URL | — |
+| `SENSORS_API_BASE_URL` | Sensors/routing API base URL (used by `GundiDataSenderClient`) | — |
 | `GUNDI_API_SSL_VERIFY` | Verify SSL certificates | `true` |
-| `LOG_LEVEL` | Logging level | `INFO` |
+| `LOG_LEVEL` | Logging level (env-only) | `INFO` |
+| `GUNDI_CLIENT_ENVFILE` | Path to a `.env` file to load (env-only; defaults to `.env` in cwd) | — |
+
+### GundiClient constructor kwargs
+
+| Kwarg | Corresponding env var | Description |
+|---|---|---|
+| `base_url` | `GUNDI_API_BASE_URL` | Gundi API base URL |
+| `use_ssl` | `GUNDI_API_SSL_VERIFY` | Verify SSL certificates |
+| `username` | `GUNDI_USERNAME` | Gundi username |
+| `password` | `GUNDI_PASSWORD` | Gundi password |
+| `oauth_client_id` | `OAUTH_CLIENT_ID` | OAuth client ID |
+| `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | OAuth client secret |
+| `oauth_token_url` | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL |
+| `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience |
+| `oauth_scope` | `OAUTH_SCOPE` | OAuth scope |
+| `max_http_retries` | — | Max HTTP retries (default `5`) |
+| `connect_timeout` | — | Connect timeout in seconds (default `3.1`) |
+| `data_timeout` | — | Data timeout in seconds (default `20`) |
+
+> **Note:** `OAUTH_ISSUER` has no constructor kwarg counterpart. Set `oauth_token_url` directly when constructing a client programmatically.
+
+### GundiDataSenderClient constructor kwargs
+
+| Kwarg | Corresponding env var | Description |
+|---|---|---|
+| `integration_api_key` | — | API key for the integration (required) |
+| `sensors_api_base_url` | `SENSORS_API_BASE_URL` | Sensors/routing API base URL |
 
 ## Authentication
 
@@ -105,7 +136,7 @@ The client supports two authentication modes:
 
 **Client credentials grant (for services)** — Provide `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. This is used by internal backend services.
 
-> **Note:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) and `keycloak_*` constructor kwargs are still accepted for backward compatibility.
+> **Backward compatibility:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) are still accepted as fallbacks for the corresponding `OAUTH_*` env vars. Three legacy constructor kwargs are also still accepted: `keycloak_client_id`, `keycloak_client_secret`, and `keycloak_audience`. There is no `keycloak_issuer` constructor kwarg — use `oauth_token_url` instead.
 
 If both are configured, password grant takes precedence. Contact the Gundi team for credentials.
 
@@ -114,58 +145,72 @@ If both are configured, password grant takes precedence. Contact the Gundi team 
 Use `GundiClient` as an async context manager to query the Gundi API.
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient
 
-async with GundiClient() as client:
-    # List integrations you have access to (async generator — paginated)
-    async for integration in client.get_integrations():
-        print(integration.name, integration.id)
+async def main():
+    async with GundiClient() as client:
+        # List integrations you have access to (async generator — paginated)
+        async for integration in client.get_integrations():
+            print(integration.name, integration.id)
 
-    # Find an integration by name and get its API key
-    target = None
-    async for i in client.get_integrations():
-        if i.name == "My Integration":
-            target = i
-            break
-    api_key = await client.get_integration_api_key(
-        integration_id=str(target.id)
-    )
+        # Find an integration by name and get its API key
+        target = None
+        async for i in client.get_integrations():
+            if i.name == "My Integration":
+                target = i
+                break
+        if target is None:
+            raise RuntimeError("Integration 'My Integration' not found")
+        api_key = await client.get_integration_api_key(
+            integration_id=str(target.id)
+        )
 
-    # List connections
-    connections = await client.get_connections()
+        # List connections
+        connections = await client.get_connections()
 
-    # Get connection details
-    connection = await client.get_connection_details(
-        integration_id="some-uuid"
-    )
+        # Get connection details
+        connection = await client.get_connection_details(
+            integration_id="some-uuid"
+        )
 
-    # Get integration details
-    integration = await client.get_integration_details(
-        integration_id="some-uuid"
-    )
+        # Get integration details
+        integration = await client.get_integration_details(
+            integration_id="some-uuid"
+        )
 
-    # Get route details
-    route = await client.get_route_details(route_id="some-uuid")
+        # Get route details
+        route = await client.get_route_details(route_id="some-uuid")
 
-    # Query traces
-    traces = await client.get_traces(params={"object_id": "some-uuid"})
+        # Query traces
+        traces = await client.get_traces(params={"object_id": "some-uuid"})
 
-    # Register an integration type
-    integration_type = await client.register_integration_type(
-        data={"name": "MyIntegration", "value": "my_integration"}
-    )
+        # Register an integration type
+        integration_type = await client.register_integration_type(
+            data={"name": "MyIntegration", "value": "my_integration"}
+        )
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 You can also create a client without a context manager and close it manually:
 
 ```python
-client = GundiClient()
-try:
-    connection = await client.get_connection_details(
-        integration_id="some-uuid"
-    )
-finally:
-    await client.close()
+import asyncio
+from gundi_client_v2 import GundiClient
+
+async def main():
+    client = GundiClient()
+    try:
+        connection = await client.get_connection_details(
+            integration_id="some-uuid"
+        )
+    finally:
+        await client.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Usage: GundiDataSenderClient
@@ -173,54 +218,59 @@ finally:
 Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials.
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiDataSenderClient
 
-sender = GundiDataSenderClient(integration_api_key="your-api-key")
+async def main():
+    sender = GundiDataSenderClient(integration_api_key="your-api-key")
 
-# Post observations
-await sender.post_observations(data=[
-    {
-        "source": "device-123",
-        "source_name": "GPS Tracker",
-        "type": "tracking-device",
-        "recorded_at": "2024-01-15T10:30:00Z",
-        "location": {"lat": -1.286389, "lon": 36.817223},
-    }
-])
+    # Post observations
+    await sender.post_observations(data=[
+        {
+            "source": "device-123",
+            "source_name": "GPS Tracker",
+            "type": "tracking-device",
+            "recorded_at": "2024-01-15T10:30:00Z",
+            "location": {"lat": -1.286389, "lon": 36.817223},
+        }
+    ])
 
-# Post events
-await sender.post_events(data=[
-    {
-        "title": "Animal Detected",
-        "event_type": "wildlife_sighting_rep",
-        "recorded_at": "2024-01-15T10:30:00Z",
-        "location": {"lat": -1.286389, "lon": 36.817223},
-        "event_details": {"species": "lion"},
-    }
-])
+    # Post events
+    await sender.post_events(data=[
+        {
+            "title": "Animal Detected",
+            "event_type": "wildlife_sighting_rep",
+            "recorded_at": "2024-01-15T10:30:00Z",
+            "location": {"lat": -1.286389, "lon": 36.817223},
+            "event_details": {"species": "lion"},
+        }
+    ])
 
-# Post messages
-await sender.post_messages(data=[
-    {
-        "sender": "ranger-radio-1",
-        "recipients": ["hq@example.org"],
-        "text": "All clear at checkpoint.",
-        "recorded_at": "2024-01-15T10:30:00Z",
-    }
-])
+    # Post messages
+    await sender.post_messages(data=[
+        {
+            "sender": "ranger-radio-1",
+            "recipients": ["hq@example.org"],
+            "text": "All clear at checkpoint.",
+            "recorded_at": "2024-01-15T10:30:00Z",
+        }
+    ])
 
-# Update an event
-await sender.update_event(
-    event_id="event-uuid",
-    data={"title": "Updated Title"},
-)
-
-# Post event attachments
-with open("photo.jpg", "rb") as f:
-    await sender.post_event_attachments(
+    # Update an event
+    await sender.update_event(
         event_id="event-uuid",
-        attachments=[("photo.jpg", f.read())],
+        data={"title": "Updated Title"},
     )
+
+    # Post event attachments
+    with open("photo.jpg", "rb") as f:
+        await sender.post_event_attachments(
+            event_id="event-uuid",
+            attachments=[("photo.jpg", f.read())],
+        )
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Error Handling
@@ -228,22 +278,27 @@ with open("photo.jpg", "rb") as f:
 The client raises specific exceptions for different failure modes:
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient, AuthenticationError, GundiAPIError, GundiClientError
 
-async with GundiClient() as client:
-    try:
-        connection = await client.get_connection_details(
-            integration_id="some-uuid"
-        )
-    except AuthenticationError as e:
-        # OAuth token request failed (bad credentials, expired, etc.)
-        print(f"Auth failed: {e}")
-    except GundiAPIError as e:
-        # Non-2xx response from the API
-        print(f"API error {e.status_code}: {e.detail}")
-    except GundiClientError as e:
-        # Base exception for all client errors
-        print(f"Client error: {e}")
+async def main():
+    async with GundiClient() as client:
+        try:
+            connection = await client.get_connection_details(
+                integration_id="some-uuid"
+            )
+        except AuthenticationError as e:
+            # OAuth token request failed (bad credentials, expired, etc.)
+            print(f"Auth failed: {e}")
+        except GundiAPIError as e:
+            # Non-2xx response from the API
+            print(f"API error {e.status_code}: {e.detail}")
+        except GundiClientError as e:
+            # Base exception for all client errors
+            print(f"Client error: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,55 +1,251 @@
-# Gundi Client
-## Introduction
-[Gundi](https://www.earthranger.com/), a.k.a "The Portal" is a platform to manage integrations.
-The gundi-client is an async python client to interact with Gundi's REST API.
+# Gundi Client v2
+
+An async Python client for the [Gundi](https://www.earthranger.com/) API. Gundi (a.k.a. "The Portal") is a platform for managing wildlife conservation integrations — connecting sensors, cameras, and other data sources to analytical platforms like EarthRanger.
+
+This library provides two clients:
+- **`GundiClient`** — query connections, integrations, routes, and traces
+- **`GundiDataSenderClient`** — post observations, events, and messages
 
 ## Installation
-```
+
+```bash
 pip install gundi-client-v2
 ```
 
-## Usage
+## Quick Start
 
-```
+```python
 from gundi_client_v2 import GundiClient
-import httpx
 
-# You can use it as an async context-managed client
 async with GundiClient() as client:
-   try:
     connection = await client.get_connection_details(
-        integration_id="some-integration-uuid"
+        integration_id="your-integration-uuid"
     )
-    except httpx.RequestError as e:
-        logger.exception("Request Error")   
-        ...
-    except httpx.TimeoutException as e:
-        logger.exception("Request timed out")
-        ...
-    except httpx.HTTPStatusError as e:
-        logger.exception("Response returned error")
-    else:
-        for integration in connection.destinations:  
-            ...
-   ...
+    print(connection.provider.name)
+```
 
-# Or create an instance and close the client explicitly later
+Set your credentials via environment variables (see [Configuration](#configuration)) or pass them directly:
+
+```python
+client = GundiClient(
+    username="you@example.com",
+    password="your-password",
+    oauth_client_id="your-client-id",
+    oauth_audience="your-audience",
+    oauth_token_url="https://auth.example.com/.../token",
+    base_url="https://api.example.com",
+)
+```
+
+### End-to-End: List, Get Key, Send Data
+
+```python
+from gundi_client_v2 import GundiClient, GundiDataSenderClient
+
+async with GundiClient() as client:
+    # 1. List integrations and find yours by name
+    my_integration = None
+    async for i in client.get_integrations():
+        if i.name == "My Integration":
+            my_integration = i
+            break
+
+    # 2. Get the API key for that integration
+    api_key = await client.get_integration_api_key(
+        integration_id=str(my_integration.id)
+    )
+
+# 3. Use the API key to send data
+sender = GundiDataSenderClient(integration_api_key=api_key)
+await sender.post_events(data=[
+    {
+        "title": "Animal Detected",
+        "event_type": "wildlife_sighting_rep",
+        "recorded_at": "2024-01-15T10:30:00Z",
+        "location": {"lat": -1.286, "lon": 36.817},
+        "event_details": {"species": "lion"},
+    }
+])
+```
+
+## Configuration
+
+All settings can be provided as environment variables or keyword arguments to the client constructor.
+
+### Developer Authentication
+
+| Variable | Description | Required |
+|---|---|---|
+| `GUNDI_USERNAME` | Your Gundi username (email) | Yes (for password auth) |
+| `GUNDI_PASSWORD` | Your Gundi password | Yes (for password auth) |
+
+### Service Authentication
+
+| Variable | Description | Required |
+|---|---|---|
+| `OAUTH_CLIENT_ID` | OAuth client ID | Yes |
+| `OAUTH_CLIENT_SECRET` | OAuth client secret | Yes (for client credentials auth) |
+
+### Common
+
+| Variable | Description | Default |
+|---|---|---|
+| `OAUTH_ISSUER` | OAuth issuer URL (token URL is derived as `{issuer}/protocol/openid-connect/token`) | — |
+| `OAUTH_AUDIENCE` | OAuth audience | — |
+| `GUNDI_API_BASE_URL` | Gundi API base URL | — |
+| `SENSORS_API_BASE_URL` | Sensors/routing API base URL | — |
+| `GUNDI_API_SSL_VERIFY` | Verify SSL certificates | `true` |
+| `LOG_LEVEL` | Logging level | `INFO` |
+
+## Authentication
+
+The client supports two authentication modes:
+
+**Password grant (for developers)** — Provide `GUNDI_USERNAME` and `GUNDI_PASSWORD` along with `OAUTH_CLIENT_ID`. This is the recommended approach for external developers.
+
+**Client credentials grant (for services)** — Provide `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. This is used by internal backend services.
+
+> **Note:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) and `keycloak_*` constructor kwargs are still accepted for backward compatibility.
+
+If both are configured, password grant takes precedence. Contact the Gundi team for credentials.
+
+## Usage: GundiClient
+
+Use `GundiClient` as an async context manager to query the Gundi API.
+
+```python
+from gundi_client_v2 import GundiClient
+
+async with GundiClient() as client:
+    # List integrations you have access to (async generator — paginated)
+    async for integration in client.get_integrations():
+        print(integration.name, integration.id)
+
+    # Find an integration by name and get its API key
+    target = None
+    async for i in client.get_integrations():
+        if i.name == "My Integration":
+            target = i
+            break
+    api_key = await client.get_integration_api_key(
+        integration_id=str(target.id)
+    )
+
+    # List connections
+    connections = await client.get_connections()
+
+    # Get connection details
+    connection = await client.get_connection_details(
+        integration_id="some-uuid"
+    )
+
+    # Get integration details
+    integration = await client.get_integration_details(
+        integration_id="some-uuid"
+    )
+
+    # Get route details
+    route = await client.get_route_details(route_id="some-uuid")
+
+    # Query traces
+    traces = await client.get_traces(params={"object_id": "some-uuid"})
+
+    # Register an integration type
+    integration_type = await client.register_integration_type(
+        data={"name": "MyIntegration", "value": "my_integration"}
+    )
+```
+
+You can also create a client without a context manager and close it manually:
+
+```python
 client = GundiClient()
 try:
-    response = await client.get_connection_details(
-        integration_id="some-integration-uuid"
+    connection = await client.get_connection_details(
+        integration_id="some-uuid"
     )
-    except httpx.RequestError as e:
-        logger.exception("Request Error")   
-        ...
-    except httpx.TimeoutException as e:
-        logger.exception("Request timed out")
-        ...
-    except httpx.HTTPStatusError as e:
-        logger.exception("Response returned error")
-    else:
-        for integration in connection.destinations:
-            ...
-   ...
-   await client.close()  # Close the session used to send requests to Gundi
+finally:
+    await client.close()
 ```
+
+## Usage: GundiDataSenderClient
+
+Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials.
+
+```python
+from gundi_client_v2 import GundiDataSenderClient
+
+sender = GundiDataSenderClient(integration_api_key="your-api-key")
+
+# Post observations
+await sender.post_observations(data=[
+    {
+        "source": "device-123",
+        "source_name": "GPS Tracker",
+        "type": "tracking-device",
+        "recorded_at": "2024-01-15T10:30:00Z",
+        "location": {"lat": -1.286389, "lon": 36.817223},
+    }
+])
+
+# Post events
+await sender.post_events(data=[
+    {
+        "title": "Animal Detected",
+        "event_type": "wildlife_sighting_rep",
+        "recorded_at": "2024-01-15T10:30:00Z",
+        "location": {"lat": -1.286389, "lon": 36.817223},
+        "event_details": {"species": "lion"},
+    }
+])
+
+# Post messages
+await sender.post_messages(data=[
+    {
+        "sender": "ranger-radio-1",
+        "recipients": ["hq@example.org"],
+        "text": "All clear at checkpoint.",
+        "recorded_at": "2024-01-15T10:30:00Z",
+    }
+])
+
+# Update an event
+await sender.update_event(
+    event_id="event-uuid",
+    data={"title": "Updated Title"},
+)
+
+# Post event attachments
+with open("photo.jpg", "rb") as f:
+    await sender.post_event_attachments(
+        event_id="event-uuid",
+        attachments=[("photo.jpg", f.read())],
+    )
+```
+
+## Error Handling
+
+The client raises specific exceptions for different failure modes:
+
+```python
+from gundi_client_v2 import GundiClient, AuthenticationError, GundiAPIError, GundiClientError
+
+async with GundiClient() as client:
+    try:
+        connection = await client.get_connection_details(
+            integration_id="some-uuid"
+        )
+    except AuthenticationError as e:
+        # OAuth token request failed (bad credentials, expired, etc.)
+        print(f"Auth failed: {e}")
+    except GundiAPIError as e:
+        # Non-2xx response from the API
+        print(f"API error {e.status_code}: {e.detail}")
+    except GundiClientError as e:
+        # Base exception for all client errors
+        print(f"Client error: {e}")
+```
+
+## License
+
+Apache 2.0

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -4,16 +4,19 @@ GUNDI_USERNAME=your-username
 GUNDI_PASSWORD=your-password
 GUNDI_INTEGRATION_NAME="Your Integration Name"
 
-# OAuth (password grant). Use OAUTH_ISSUER or the full OAUTH_TOKEN_URL.
-OAUTH_ISSUER=https://cdip-auth.pamdas.org/auth/realms/cdip-dev
-OAUTH_CLIENT_ID=cdip-oauth2
-OAUTH_AUDIENCE=cdip-admin-portal
-# Optional: full token URL instead of OAUTH_ISSUER
-#OAUTH_TOKEN_URL=https://cdip-auth.pamdas.org/auth/realms/cdip-dev/protocol/openid-connect/token
+# OAuth (password grant). Set OAUTH_ISSUER and the library derives the token endpoint
+# as {OAUTH_ISSUER}/protocol/openid-connect/token. Alternatively, the example script
+# send_observations.py also accepts OAUTH_TOKEN_URL directly and passes it as the
+# oauth_token_url kwarg to GundiClient (the library does not read OAUTH_TOKEN_URL itself).
+OAUTH_ISSUER=https://auth.example.com/realms/your-realm
+OAUTH_CLIENT_ID=your-oauth-client-id
+OAUTH_AUDIENCE=your-oauth-audience
+# Optional (read only by send_observations.py): explicit token endpoint URL.
+#OAUTH_TOKEN_URL=https://auth.example.com/realms/your-realm/protocol/openid-connect/token
 
-# API base URLs (optional; defaults depend on deployment)
-GUNDI_API_BASE_URL=https://api.stage.gundiservice.org
-SENSORS_API_BASE_URL=https://sensors.api.stage.gundiservice.org
+# API base URLs (required for the example to function)
+GUNDI_API_BASE_URL=https://api.example.com
+SENSORS_API_BASE_URL=https://sensors.api.example.com
 
 # Optional
 # GUNDI_API_SSL_VERIFY=true

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to .env and fill in your values.
+# Required for examples (e.g. send_observations.py)
+GUNDI_USERNAME=your-username
+GUNDI_PASSWORD=your-password
+GUNDI_INTEGRATION_NAME="Your Integration Name"
+
+# OAuth (password grant). Use OAUTH_ISSUER or the full OAUTH_TOKEN_URL.
+OAUTH_ISSUER=https://cdip-auth.pamdas.org/auth/realms/cdip-dev
+OAUTH_CLIENT_ID=cdip-oauth2
+OAUTH_AUDIENCE=cdip-admin-portal
+# Optional: full token URL instead of OAUTH_ISSUER
+#OAUTH_TOKEN_URL=https://cdip-auth.pamdas.org/auth/realms/cdip-dev/protocol/openid-connect/token
+
+# API base URLs (optional; defaults depend on deployment)
+GUNDI_API_BASE_URL=https://api.stage.gundiservice.org
+SENSORS_API_BASE_URL=https://sensors.api.stage.gundiservice.org
+
+# Optional
+# GUNDI_API_SSL_VERIFY=true
+# LOG_LEVEL=INFO

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,47 @@
+# Gundi Client examples
+
+Simple examples for using the Gundi client with **username and password** credentials to access Gundi's API.
+
+## Setup
+
+From the repository root, install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+Then set the required environment variables (or pass credentials in code where the example allows it). You can copy `examples/.env.example` to `examples/.env` and fill in your values; the client will load `.env` from the current directory when run.
+
+## Examples
+
+### send_observations.py
+
+Demonstrates:
+
+1. Authenticating with a username and password
+2. Querying for integrations
+3. Selecting one integration by name and fetching its API key
+4. Using `GundiDataSenderClient` with that API key to send observations to Gundi
+
+**Required environment variables:**
+
+- `GUNDI_USERNAME` – your Gundi username
+- `GUNDI_PASSWORD` – your Gundi password
+- `GUNDI_INTEGRATION_NAME` – exact name of the integration to use for sending (e.g. the display name in the portal)
+
+**Optional (OAuth / API endpoints):**
+
+- `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`
+- `OAUTH_TOKEN_URL` – full OAuth token URL (overrides `OAUTH_ISSUER` if set)
+- `OAUTH_CLIENT_ID` – OAuth client id for the password grant
+- `OAUTH_AUDIENCE` – OAuth audience
+- `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
+- `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
+
+**Run:**
+
+```bash
+python examples/send_observations.py
+```
+
+Ensure the integration named in `GUNDI_INTEGRATION_NAME` exists in your Gundi deployment and has an API key configured.

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,8 +32,8 @@ Demonstrates:
 - `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
 - `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
 - At least one of:
-  - `OAUTH_TOKEN_URL` – full OAuth token URL
-  - `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. Do not include a trailing slash.
+  - `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/realms/my-realm`); the library derives the token URL as `{OAUTH_ISSUER}/protocol/openid-connect/token`. Do not include a trailing slash.
+  - `OAUTH_TOKEN_URL` – Read by `send_observations.py` and passed as the `oauth_token_url` kwarg to `GundiClient`. The library itself only derives the token URL from `OAUTH_ISSUER`; setting `OAUTH_TOKEN_URL` in the environment without using this example script has no effect on the library.
 
 **Optional:**
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ From the repository root, install the package in editable mode:
 pip install -e .
 ```
 
-Then set the required environment variables (or pass credentials in code where the example allows it). You can copy `examples/.env.example` to `examples/.env` and fill in your values; the client will load `.env` from the current directory when run.
+Then set the required environment variables (or pass credentials in code where the example allows it).
 
 ## Examples
 
@@ -28,20 +28,38 @@ Demonstrates:
 - `GUNDI_USERNAME` – your Gundi username
 - `GUNDI_PASSWORD` – your Gundi password
 - `GUNDI_INTEGRATION_NAME` – exact name of the integration to use for sending (e.g. the display name in the portal)
-
-**Optional (OAuth / API endpoints):**
-
-- `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`
-- `OAUTH_TOKEN_URL` – full OAuth token URL (overrides `OAUTH_ISSUER` if set)
-- `OAUTH_CLIENT_ID` – OAuth client id for the password grant
-- `OAUTH_AUDIENCE` – OAuth audience
+- `OAUTH_CLIENT_ID` – OAuth client ID for the password grant
 - `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
 - `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
+- At least one of:
+  - `OAUTH_TOKEN_URL` – full OAuth token URL
+  - `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. Do not include a trailing slash.
 
-**Run:**
+**Optional:**
+
+- `OAUTH_AUDIENCE` – OAuth audience
+- `GUNDI_API_SSL_VERIFY` – set to `false` to skip SSL verification (default: `true`)
+
+**Setting up credentials with a `.env` file:**
+
+Copy `.env.example` to `.env` (in the `examples/` directory) and fill in your values:
 
 ```bash
-python examples/send_observations.py
+cp examples/.env.example examples/.env
+# edit examples/.env
+```
+
+The client loads `.env` from the **current working directory**, so run the script from the `examples/` directory:
+
+```bash
+cd examples
+python send_observations.py
+```
+
+Alternatively, run from the repo root and point to the file explicitly:
+
+```bash
+GUNDI_CLIENT_ENVFILE=examples/.env python examples/send_observations.py
 ```
 
 Ensure the integration named in `GUNDI_INTEGRATION_NAME` exists in your Gundi deployment and has an API key configured.

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -4,10 +4,14 @@ then use GundiDataSenderClient to send observations to Gundi.
 
 Set credentials via environment variables (recommended) or pass them in code.
 
-Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME,
-          OAUTH_CLIENT_ID, GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
-          and at least one of OAUTH_TOKEN_URL or OAUTH_ISSUER.
-Optional: OAUTH_AUDIENCE, GUNDI_API_SSL_VERIFY
+# Required (read by this script; one of OAUTH_ISSUER or OAUTH_TOKEN_URL must be set):
+#   GUNDI_USERNAME, GUNDI_PASSWORD,
+#   GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
+#   OAUTH_CLIENT_ID, OAUTH_AUDIENCE,
+#   OAUTH_ISSUER  (library derives the token URL as {issuer}/protocol/openid-connect/token)
+#     OR
+#   OAUTH_TOKEN_URL  (read by this script and passed as the oauth_token_url kwarg to GundiClient)
+# Optional: OAUTH_AUDIENCE, GUNDI_API_SSL_VERIFY
 
 Run from the examples/ directory (so the .env file in that directory is loaded):
 

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -1,0 +1,101 @@
+"""
+Example: Authenticate with username/password, get an integration's API key by name,
+then use GundiDataSenderClient to send observations to Gundi.
+
+Set credentials via environment variables (recommended) or pass them in code.
+Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME
+Optional: OAUTH_ISSUER (or OAUTH_TOKEN_URL), OAUTH_CLIENT_ID, OAUTH_AUDIENCE,
+          GUNDI_API_BASE_URL, SENSORS_API_BASE_URL
+"""
+
+import asyncio
+import os
+from datetime import datetime, timezone
+
+from gundi_client_v2 import GundiClient, GundiDataSenderClient
+
+
+def get_client_kwargs():
+    """Build GundiClient kwargs from environment."""
+    username = os.environ.get("GUNDI_USERNAME")
+    password = os.environ.get("GUNDI_PASSWORD")
+    if not username or not password:
+        raise ValueError(
+            "Set GUNDI_USERNAME and GUNDI_PASSWORD in the environment, or pass them in code."
+        )
+    kwargs = {"username": username, "password": password}
+    if os.environ.get("OAUTH_TOKEN_URL"):
+        kwargs["oauth_token_url"] = os.environ["OAUTH_TOKEN_URL"]
+    elif os.environ.get("OAUTH_ISSUER"):
+        kwargs["oauth_token_url"] = (
+            f"{os.environ['OAUTH_ISSUER'].rstrip('/')}/protocol/openid-connect/token"
+        )
+    if os.environ.get("OAUTH_CLIENT_ID"):
+        kwargs["oauth_client_id"] = os.environ["OAUTH_CLIENT_ID"]
+    if os.environ.get("OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = os.environ["OAUTH_AUDIENCE"]
+    if os.environ.get("GUNDI_API_BASE_URL"):
+        kwargs["base_url"] = os.environ["GUNDI_API_BASE_URL"]
+    return kwargs
+
+
+def get_sender_kwargs():
+    """Build GundiDataSenderClient kwargs from environment (optional base URL)."""
+    kwargs = {}
+    if os.environ.get("SENSORS_API_BASE_URL"):
+        kwargs["sensors_api_base_url"] = os.environ["SENSORS_API_BASE_URL"]
+    return kwargs
+
+
+async def main():
+    integration_name = os.environ.get("GUNDI_INTEGRATION_NAME")
+    if not integration_name:
+        raise ValueError(
+            "Set GUNDI_INTEGRATION_NAME to the name of the integration to use for sending."
+        )
+
+    client_kwargs = get_client_kwargs()
+    sender_kwargs = get_sender_kwargs()
+
+    async with GundiClient(**client_kwargs) as client:
+        # 1. Authenticate (implicit on first request) and query integrations
+        integration = None
+        names = []
+        async for i in client.get_integrations():
+            names.append(i.name)
+            if i.name == integration_name:
+                integration = i
+                break
+        if not integration:
+            raise ValueError(
+                f"No integration named {integration_name!r}. Available: {names}"
+            )
+
+        # 2. Get the integration's API key
+        api_key = await client.get_integration_api_key(integration.id)
+        if not api_key:
+            raise ValueError(
+                f"Integration {integration_name!r} has no API key."
+            )
+
+    # 3. Send observations using GundiDataSenderClient
+    sender = GundiDataSenderClient(
+        integration_api_key=api_key,
+        **sender_kwargs,
+    )
+    observations = [
+        {
+            "source": 2,
+            "source_name": "Python example script",
+            "type": "tracking-device",
+            "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            "location": {"lat": -12.398828, "lon": -74.263916},
+            "additional": {"example": True},
+        }
+    ]
+    response = await sender.post_observations(observations)
+    print("Sent observations. Response:", response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -3,9 +3,20 @@ Example: Authenticate with username/password, get an integration's API key by na
 then use GundiDataSenderClient to send observations to Gundi.
 
 Set credentials via environment variables (recommended) or pass them in code.
-Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME
-Optional: OAUTH_ISSUER (or OAUTH_TOKEN_URL), OAUTH_CLIENT_ID, OAUTH_AUDIENCE,
-          GUNDI_API_BASE_URL, SENSORS_API_BASE_URL
+
+Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME,
+          OAUTH_CLIENT_ID, GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
+          and at least one of OAUTH_TOKEN_URL or OAUTH_ISSUER.
+Optional: OAUTH_AUDIENCE, GUNDI_API_SSL_VERIFY
+
+Run from the examples/ directory (so the .env file in that directory is loaded):
+
+    cd examples
+    python send_observations.py
+
+Or from the repo root using GUNDI_CLIENT_ENVFILE:
+
+    GUNDI_CLIENT_ENVFILE=examples/.env python examples/send_observations.py
 """
 
 import asyncio
@@ -16,35 +27,56 @@ from gundi_client_v2 import GundiClient, GundiDataSenderClient
 
 
 def get_client_kwargs():
-    """Build GundiClient kwargs from environment."""
+    """Build GundiClient kwargs from environment, validating required settings."""
     username = os.environ.get("GUNDI_USERNAME")
     password = os.environ.get("GUNDI_PASSWORD")
     if not username or not password:
         raise ValueError(
             "Set GUNDI_USERNAME and GUNDI_PASSWORD in the environment, or pass them in code."
         )
-    kwargs = {"username": username, "password": password}
-    if os.environ.get("OAUTH_TOKEN_URL"):
-        kwargs["oauth_token_url"] = os.environ["OAUTH_TOKEN_URL"]
-    elif os.environ.get("OAUTH_ISSUER"):
-        kwargs["oauth_token_url"] = (
-            f"{os.environ['OAUTH_ISSUER'].rstrip('/')}/protocol/openid-connect/token"
+
+    oauth_client_id = os.environ.get("OAUTH_CLIENT_ID")
+    oauth_token_url = os.environ.get("OAUTH_TOKEN_URL")
+    oauth_issuer = os.environ.get("OAUTH_ISSUER")
+    gundi_api_base_url = os.environ.get("GUNDI_API_BASE_URL")
+
+    missing = []
+    if not oauth_client_id:
+        missing.append("OAUTH_CLIENT_ID")
+    if not oauth_token_url and not oauth_issuer:
+        missing.append("OAUTH_TOKEN_URL (or OAUTH_ISSUER)")
+    if not gundi_api_base_url:
+        missing.append("GUNDI_API_BASE_URL")
+    if missing:
+        raise ValueError(
+            f"Missing required environment variable(s): {', '.join(missing)}"
         )
-    if os.environ.get("OAUTH_CLIENT_ID"):
-        kwargs["oauth_client_id"] = os.environ["OAUTH_CLIENT_ID"]
+
+    kwargs = {"username": username, "password": password}
+    if oauth_token_url:
+        kwargs["oauth_token_url"] = oauth_token_url
+    elif oauth_issuer:
+        # Note: OAUTH_ISSUER must not have a trailing slash — the token URL is
+        # derived by appending /protocol/openid-connect/token and the value is
+        # not stripped.
+        kwargs["oauth_token_url"] = (
+            f"{oauth_issuer}/protocol/openid-connect/token"
+        )
+    kwargs["oauth_client_id"] = oauth_client_id
+    kwargs["base_url"] = gundi_api_base_url
     if os.environ.get("OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = os.environ["OAUTH_AUDIENCE"]
-    if os.environ.get("GUNDI_API_BASE_URL"):
-        kwargs["base_url"] = os.environ["GUNDI_API_BASE_URL"]
     return kwargs
 
 
 def get_sender_kwargs():
-    """Build GundiDataSenderClient kwargs from environment (optional base URL)."""
-    kwargs = {}
-    if os.environ.get("SENSORS_API_BASE_URL"):
-        kwargs["sensors_api_base_url"] = os.environ["SENSORS_API_BASE_URL"]
-    return kwargs
+    """Build GundiDataSenderClient kwargs from environment, validating required settings."""
+    sensors_api_base_url = os.environ.get("SENSORS_API_BASE_URL")
+    if not sensors_api_base_url:
+        raise ValueError(
+            "Missing required environment variable: SENSORS_API_BASE_URL"
+        )
+    return {"sensors_api_base_url": sensors_api_base_url}
 
 
 async def main():
@@ -66,7 +98,7 @@ async def main():
             if i.name == integration_name:
                 integration = i
                 break
-        if not integration:
+        if integration is None:
             raise ValueError(
                 f"No integration named {integration_name!r}. Available: {names}"
             )


### PR DESCRIPTION
## Summary
PR 6/6. Stacked on the password-grant PR.

- README usage docs + `examples/` for both clients, `oauth_*`/`keycloak_*` config, password grant, and the new read methods
- Fixed docs that awaited `get_integrations()` (it's an async generator -> `async for`)

## Test Plan
- [x] `pytest` — 35 passed (docs-only; example parses via `ast`)