### PR TITLE
ci: publish gundi-client-v2 to PyPI on tag push (Trusted Publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    # Pinned (not `ubuntu-latest`) so a future GitHub runner refresh can't
+    # silently change the OS/packages under a release pipeline.
+    runs-on: ubuntu-24.04
     # Pin to a named environment so the PyPI Trusted Publisher config can
     # be scoped to `pypi` and PRs from forks cannot trigger a release.
     environment:
@@ -25,13 +27,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up uv
+      - name: Set up uv (with a pinned Python)
+        # `python-version` on setup-uv installs the requested CPython AND makes
+        # it the interpreter every subsequent `uv sync` / `uv run` resolves to,
+        # so the release build/tests are reproducible regardless of what
+        # interpreter happens to be first on the runner's PATH.
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-
-      - name: Set up Python
-        run: uv python install 3.11
+          python-version: "3.11"
 
       - name: Install dependencies
         # uv sync installs the project plus the `dev` dependency group by default.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,26 @@ jobs:
         # commit. Without this, a broken tag would still ship to PyPI.
         run: uv run pytest -q
 
-      - name: Verify package version matches tag
-        # The package version comes from gundi_client_v2/__init__.py via
-        # hatchling's dynamic version. Make sure the pushed tag matches
-        # it, otherwise the wheel would ship under a version that doesn't
-        # reflect the tag.
+      - name: Verify tag is a strict release and matches __version__
+        # 1. The trigger glob `v*.*.*` would happily match pre-release tags
+        #    like `v1.2.3-rc1` — the last `*` is greedy. Reject anything
+        #    that isn't strictly vX.Y.Z so a stray pre-release tag can't
+        #    accidentally publish to production PyPI.
+        # 2. Parse __version__ directly from the source file (matching how
+        #    hatchling reads it) instead of importing the package — that
+        #    avoids pulling in httpx, gundi-core, and every other
+        #    module-level import just to read a string.
         run: |
           tag_version="${GITHUB_REF_NAME#v}"
-          pkg_version=$(uv run python -c "from gundi_client_v2 import __version__; print(__version__)")
+          if [[ ! "$tag_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' is not a strict vX.Y.Z release tag; pre-release/build tags are not allowed by this workflow."
+            exit 1
+          fi
+          pkg_version=$(awk -F'["'"'"']' '/^__version__[[:space:]]*=/ {print $2; exit}' gundi_client_v2/__init__.py)
+          if [ -z "$pkg_version" ]; then
+            echo "::error::Could not parse __version__ from gundi_client_v2/__init__.py"
+            exit 1
+          fi
           if [ "$tag_version" != "$pkg_version" ]; then
             echo "::error::Tag ($tag_version) and __version__ ($pkg_version) differ"
             exit 1
@@ -67,13 +79,27 @@ jobs:
         # config on pypi.org: pypi.org/manage/account/publishing/ →
         # add a trusted publisher for `gundi-client-v2` pointing at
         # this repo, workflow `release.yml`, environment `pypi`.
+        # skip-existing makes a re-run of the workflow (e.g. after a
+        # transient failure later in the job) safe — PyPI rejects
+        # re-uploading the same version, and without this flag the action
+        # would surface that rejection as a hard error.
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
+        # Idempotent: on a re-run, the release for this tag already exists;
+        # `gh release create` would fail. Detect that case and upload (with
+        # --clobber to overwrite) instead of trying to recreate.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes \
-            dist/*
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; uploading artifacts to it."
+            gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --generate-notes \
+              dist/*
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+# `id-token: write` is required for PyPI Trusted Publishing (OIDC).
+# `contents: write` is required for the GitHub Release upload step.
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    # Pin to a named environment so the PyPI Trusted Publisher config can
+    # be scoped to `pypi` and PRs from forks cannot trigger a release.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gundi-client-v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        # uv sync installs the project plus the `dev` dependency group by default.
+        run: uv sync
+
+      - name: Run tests
+        # Gate the release on the test suite passing against the tagged
+        # commit. Without this, a broken tag would still ship to PyPI.
+        run: uv run pytest -q
+
+      - name: Verify package version matches tag
+        # The package version comes from gundi_client_v2/__init__.py via
+        # hatchling's dynamic version. Make sure the pushed tag matches
+        # it, otherwise the wheel would ship under a version that doesn't
+        # reflect the tag.
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version=$(uv run python -c "from gundi_client_v2 import __version__; print(__version__)")
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag ($tag_version) and __version__ ($pkg_version) differ"
+            exit 1
+          fi
+          echo "Tag and package both at $pkg_version"
+
+      - name: Build wheel and sdist
+        run: uv build
+
+      - name: Show built artifacts
+        run: ls -la dist/
+
+      - name: Publish to PyPI
+        # Trusted Publisher (OIDC) — no API token. Requires a one-time
+        # config on pypi.org: pypi.org/manage/account/publishing/ →
+        # add a trusted publisher for `gundi-client-v2` pointing at
+        # this repo, workflow `release.yml`, environment `pypi`.
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            dist/*


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release.yml`, modeled on `smartconnect-client/release.yml` and adapted for the uv/hatchling build (#34).

On a `vX.Y.Z` tag push, the workflow:
- runs the test suite against the tagged commit (`uv run pytest -q`),
- verifies the tag matches the package `__version__` (read from `gundi_client_v2/__init__.py`),
- builds wheel + sdist via hatchling (`uv build`),
- publishes to PyPI using **Trusted Publishing (OIDC) — no API token required**,
- creates a GitHub Release with the built artifacts attached.

## One-time setup required before the first release
1. **Create a `pypi` environment** in this repo's settings (Settings → Environments → `pypi`). The workflow is pinned to it so PRs from forks cannot trigger a release.
2. **Register a Trusted Publisher on PyPI** at https://pypi.org/manage/account/publishing/ for the project name `gundi-client-v2`, pointing at this repo, workflow `release.yml`, environment `pypi`.

Once those are in place, releasing is `git tag v2.5.0 && git push origin v2.5.0`.

## Notes
- Independent of the open stack (#35–#39); only depends on #34's uv/hatchling pyproject, which is already merged.
- The workflow only runs on tag push, so it cannot fire on this PR or on any open PR.
- Local smoke build confirmed `uv build` produces `gundi_client_v2-2.4.1.tar.gz` and `gundi_client_v2-2.4.1-py3-none-any.whl` cleanly.

## Test Plan
- [x] `uv build` locally produces a valid wheel + sdist
- [x] YAML is valid; trigger is scoped to `v*.*.*` tags only
- [ ] (post-merge, one-time) PyPI Trusted Publisher + GitHub `pypi` environment configured
- [ ] (first release) push `v2.5.0` tag after the rest of the stack lands; verify workflow publishes successfully