### PR TITLE
feat: OIDC discovery + drop uma-ticket grant

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,145 @@
+# Migration guide
+
+## Upgrading to 3.0 from 2.x
+
+This release modernizes the OAuth2 implementation, bumps the `httpx` runtime
+dependency, and adds OIDC discovery and routes CRUD. Most consumers will need
+to update their lockfile and bump a small set of transitive dependencies.
+
+### TL;DR — what every consumer needs to change
+
+1. **Bump the pin** in `requirements-base.in` (or equivalent):
+   `gundi-client-v2~=2.4.0` → `gundi-client-v2~=3.0.0`
+2. **Bump fastapi and starlette together** if you use FastAPI's `TestClient`
+   (most integrations do). Minimum compatible quadruple:
+
+   | Package | Minimum | Reason |
+   |---|---|---|
+   | `gundi-client-v2` | `3.0.0` | this release |
+   | `httpx` | `0.28` | required transitively |
+   | `starlette` | `0.37` | older versions call `httpx.Client(app=...)`, which `httpx>=0.28` removed |
+   | `fastapi` | `0.110.3` | first release that allows `starlette>=0.37`; still compatible with `pydantic~=1.10` |
+
+3. **Regenerate the lockfile** (`uv pip compile -o requirements.txt ...` or the
+   equivalent `pip-compile` invocation).
+4. **Run your test suite.** If a `TestClient(app)` call raises
+   `TypeError: Client.__init__() got an unexpected keyword argument 'app'`,
+   your starlette is still pinned below 0.37 — your fastapi bump didn't go
+   high enough.
+
+A known-good combination tested against `gundi-integration-earthranger`:
+
+```
+gundi-client-v2==3.0.0
+httpx==0.28.1
+starlette==0.37.2
+fastapi==0.110.3
+pydantic==1.10.26   # still on the v1 line; v2 not required
+```
+
+### Authentication: uma-ticket grant removed
+
+`gundi-client-v2` no longer uses the Keycloak-specific `uma-ticket` grant for
+server-to-server authentication. It now uses the standard OAuth2
+`client_credentials` grant (RFC 6749 §4.4).
+
+**What this means at the call site:** nothing. The client constructor signature
+is unchanged. `GundiClient()` reads the same env vars and still authenticates
+transparently before each request.
+
+**What this means at the IdP:** if your service uses a confidential client
+configured for the uma-ticket flow specifically, confirm the same client can
+issue tokens via `client_credentials`. For Keycloak, this is the default; no
+change required unless you have explicitly disabled the grant. For Auth0, see
+the audience note below.
+
+### Settings: token URL derivation → OIDC discovery
+
+**Old behavior (2.x):** the client constructed the token URL at import time:
+
+```python
+# 2.x — in gundi_client_v2/settings.py
+KEYCLOAK_ISSUER = env.str("KEYCLOAK_ISSUER", None)
+OAUTH_TOKEN_URL = f"{KEYCLOAK_ISSUER}/protocol/openid-connect/token"
+```
+
+This worked only against Keycloak-shaped paths.
+
+**New behavior (3.0):** the client either reads `OAUTH_TOKEN_URL` directly, or
+discovers it via OIDC at `{OAUTH_ISSUER}/.well-known/openid-configuration`.
+The pre-existing env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`,
+`KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) still work — they're aliased to
+the corresponding `OAUTH_*` names.
+
+**Migration paths, in order of preference:**
+
+1. **No changes needed (recommended)** if your deployment already exports
+   `KEYCLOAK_ISSUER` and your IdP serves a well-formed
+   `/.well-known/openid-configuration` document (Keycloak, Auth0, Okta, Azure
+   AD, etc.). The client will discover the token endpoint at runtime, validate
+   the `issuer` claim per OIDC Discovery 1.0 §4.3, and cache the result for
+   the process lifetime.
+2. **Set `OAUTH_TOKEN_URL` directly** if your IdP doesn't expose a discovery
+   document or you want to skip the one-time discovery request. This overrides
+   discovery when set.
+
+**What does NOT work anymore:** setting only `KEYCLOAK_AUTH_SERVICE` and
+`KEYCLOAK_REALM` in env (without `KEYCLOAK_ISSUER` or `OAUTH_ISSUER` or
+`OAUTH_TOKEN_URL`). The 2.x library did not read those two env vars either —
+your existing deployment must be exporting `KEYCLOAK_ISSUER` already, or 2.x
+authentication wouldn't have worked.
+
+### OAuth audience (`OAUTH_AUDIENCE` / `KEYCLOAK_AUDIENCE`)
+
+This parameter is IdP-dependent:
+
+- **Auth0 password grant**: required. Without it, Auth0 issues an opaque token
+  that cannot be used as an API access token.
+- **Keycloak password grant**: ignored. The `aud` claim is determined by the
+  client configuration in the realm.
+- **Other IdPs**: consult their documentation. RFC 8707 specifies the
+  `resource` parameter as the standard alternative for resource indicators;
+  some IdPs accept either.
+
+The library passes whatever you set; it does not interpret the value.
+
+### New capabilities (opt-in)
+
+These are available after upgrade but don't require changes to existing code:
+
+- **OIDC discovery** via `OAUTH_ISSUER` env var or the `oauth_issuer` kwarg
+  to `GundiClient(...)`. See `gundi_client_v2/auth.py::discover_token_endpoint`.
+- **Routes CRUD**: `get_routes()`, `get_route_details(route_id)`,
+  `get_routes_for_connection(connection_id)`, `create_route(data)`,
+  `update_route(route_id, data)`, `delete_route(route_id)`.
+- **Password grant** for user-facing flows (existing in 2.x, refined in 3.0).
+  See `examples/list_connections_password_grant.py`.
+- **Refresh token rotation** handled per RFC 6749 §6 (server may omit the
+  rotated refresh token; the client reuses the cached one).
+
+### Troubleshooting
+
+**`TypeError: Client.__init__() got an unexpected keyword argument 'app'`**
+Your starlette is below 0.37 but httpx is 0.28+. Bump fastapi to `>=0.110.3`
+and re-resolve.
+
+**`pip` resolver fails to find a satisfying set of versions**
+Most often: your lockfile pins `httpcore==0.17.x` (paired with httpx 0.24). Run
+a fresh resolve, don't try to install on top of the old lockfile.
+
+**`AuthenticationError: OIDC discovery failed for ...`**
+The client tried to discover the token endpoint and got a network error. Check
+network reachability to your IdP and that `{OAUTH_ISSUER}/.well-known/openid-configuration`
+returns a 200. As a fallback, set `OAUTH_TOKEN_URL` directly.
+
+**`AuthenticationError: ...returned issuer ...does not match the expected issuer`**
+The discovery document's `issuer` claim doesn't match the URL the client used
+to fetch it. This is the OIDC Discovery 1.0 §4.3 validation. Common causes:
+trailing slash differences (the client normalizes via `rstrip('/')` on both
+sides, so this shouldn't trip you up), or an IdP misconfiguration.
+
+**Authentication worked in 2.x but fails in 3.0 with no obvious error**
+Check that the deployment env actually exports `KEYCLOAK_ISSUER` (or
+`OAUTH_ISSUER` or `OAUTH_TOKEN_URL`). Some consumer settings modules compose
+`KEYCLOAK_ISSUER` from `KEYCLOAK_AUTH_SERVICE + KEYCLOAK_REALM` as a Python
+local variable, which the client cannot see.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `GUNDI_PASSWORD` | Your Gundi password — required for password grant | — |
 | `OAUTH_CLIENT_ID` | OAuth client ID | — |
 | `OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
-| `OAUTH_ISSUER` | OAuth issuer base URL; the token URL is derived from it as `{OAUTH_ISSUER}/protocol/openid-connect/token`. **Do not include a trailing slash** — the value is not stripped and a trailing slash will produce a double-slash in the derived URL. There is no `OAUTH_TOKEN_URL` env var; use the `oauth_token_url` kwarg if you need to override the derivation. | — |
+| `OAUTH_ISSUER` | OIDC issuer URL. When set without `OAUTH_TOKEN_URL`, the token endpoint is discovered at runtime from `{OAUTH_ISSUER}/.well-known/openid-configuration`. A trailing slash is normalized. | — |
+| `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, overrides OIDC discovery from `OAUTH_ISSUER`. | — |
 | `OAUTH_AUDIENCE` | OAuth audience | — |
 | `OAUTH_SCOPE` | OAuth scope | `openid` |
 | `GUNDI_API_BASE_URL` | Gundi API base URL | — |
@@ -115,14 +116,13 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `password` | `GUNDI_PASSWORD` | Gundi password |
 | `oauth_client_id` | `OAUTH_CLIENT_ID` | OAuth client ID |
 | `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | OAuth client secret |
-| `oauth_token_url` | — (derived from `OAUTH_ISSUER`) | Full OAuth token endpoint URL. No direct env-var counterpart — set `OAUTH_ISSUER` to have the token URL derived, or pass this kwarg to override. |
+| `oauth_token_url` | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, used as-is. |
+| `oauth_issuer` | `OAUTH_ISSUER` | OIDC issuer URL. When set without `oauth_token_url`, the token endpoint is discovered via OIDC discovery. |
 | `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience |
 | `oauth_scope` | `OAUTH_SCOPE` | OAuth scope |
 | `max_http_retries` | — | Max HTTP retries (default `5`) |
 | `connect_timeout` | — | Connect timeout in seconds (default `3.1`) |
 | `data_timeout` | — | Data timeout in seconds (default `20`) |
-
-> **Note:** `OAUTH_ISSUER` has no constructor kwarg counterpart. Set `oauth_token_url` directly when constructing a client programmatically.
 
 ### GundiDataSenderClient constructor kwargs
 
@@ -139,7 +139,17 @@ The client supports two authentication modes:
 
 **Client credentials grant (for services)** — Provide `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. This is used by internal backend services.
 
-> **Backward compatibility:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) are still accepted as fallbacks for the corresponding `OAUTH_*` env vars. Three legacy constructor kwargs are also still accepted: `keycloak_client_id`, `keycloak_client_secret`, and `keycloak_audience`. There is no `keycloak_issuer` constructor kwarg — use `oauth_token_url` instead.
+### Token URL resolution
+
+The client resolves the OAuth token endpoint in this order:
+
+1. **`oauth_token_url` (kwarg) / `OAUTH_TOKEN_URL` (env)** — used as-is when set.
+2. **`oauth_issuer` (kwarg) / `OAUTH_ISSUER` (env)** — the client fetches `{issuer}/.well-known/openid-configuration` (OIDC discovery) and uses its `token_endpoint`. Result is cached for the process lifetime; call `gundi_client_v2.auth.clear_discovery_cache()` to invalidate.
+3. **Neither set** — `AuthenticationError("No token URL configured.")` is raised on the first auth attempt.
+
+OIDC discovery works for any compliant IdP (Keycloak, Auth0, Okta, …). Configure `OAUTH_ISSUER` and the token endpoint is found automatically.
+
+> **Backward compatibility:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) are still accepted as fallbacks for the corresponding `OAUTH_*` env vars. Three legacy constructor kwargs are also still accepted: `keycloak_client_id`, `keycloak_client_secret`, and `keycloak_audience`. There is no `keycloak_issuer` constructor kwarg — use `oauth_token_url` or `oauth_issuer` instead.
 
 If both are configured, password grant takes precedence. Contact the Gundi team for credentials.
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,33 @@ async def main():
             integration_id="some-uuid"
         )
 
+        # List routes (optionally pass params= for server-side filtering)
+        routes = await client.get_routes()
+
+        # List routes where a connection is the data provider
+        routes = await client.get_routes_for_connection(
+            connection_id="some-provider-uuid"
+        )
+
         # Get route details
         route = await client.get_route_details(route_id="some-uuid")
+
+        # Create a route
+        new_route = await client.create_route(data={
+            "name": "TrapTagger → ER (events)",
+            "owner": "your-org-uuid",
+            "data_providers": ["provider-integration-uuid"],
+            "destinations": ["destination-integration-uuid"],
+        })
+
+        # Update a route (partial update via PATCH)
+        updated_route = await client.update_route(
+            route_id="some-uuid",
+            data={"name": "Renamed Route"},
+        )
+
+        # Delete a route
+        await client.delete_route(route_id="some-uuid")
 
         # Query traces
         traces = await client.get_traces(params={"object_id": "some-uuid"})

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ client = GundiClient(
 
 ```python
 import asyncio
+import os
 from gundi_client_v2 import GundiClient, GundiDataSenderClient
 
 async def main():
@@ -65,7 +66,10 @@ async def main():
         )
 
     # 3. Use the API key to send data
-    sender = GundiDataSenderClient(integration_api_key=api_key)
+    sender = GundiDataSenderClient(
+        integration_api_key=api_key,
+        sensors_api_base_url=os.environ["SENSORS_API_BASE_URL"],  # or pass the URL directly
+    )
     await sender.post_events(data=[
         {
             "title": "Animal Detected",
@@ -214,14 +218,18 @@ if __name__ == "__main__":
 
 ## Usage: GundiDataSenderClient
 
-Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials.
+Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials. `sensors_api_base_url` is required — you can set it via the `SENSORS_API_BASE_URL` environment variable (as the example script does) or pass it directly.
 
 ```python
 import asyncio
+import os
 from gundi_client_v2 import GundiDataSenderClient
 
 async def main():
-    sender = GundiDataSenderClient(integration_api_key="your-api-key")
+    sender = GundiDataSenderClient(
+        integration_api_key="your-api-key",
+        sensors_api_base_url=os.environ["SENSORS_API_BASE_URL"],  # or pass the URL directly
+    )
 
     # Post observations
     await sender.post_observations(data=[

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ OIDC discovery works for any compliant IdP (Keycloak, Auth0, Okta, …). Configu
 `OAUTH_AUDIENCE` is sent to the token endpoint when configured. Whether it is required depends on the IdP:
 
 - **Auth0** — required. Without `audience`, Auth0 issues an opaque token that cannot authorize API requests.
-- **Keycloak** — optional. The password grant ignores it; UMA flows use it for scope matching.
+- **Keycloak** — optional. Both grant types this library supports (password and client_credentials) ignore it.
 
 The parameter name `audience` reflects the Auth0/Keycloak convention. The OAuth 2.0 / OIDC standard equivalent is `resource` (RFC 8707, *Resource Indicators*). If we add support for IdPs that strictly require `resource` instead, it will be introduced as a `resource` kwarg alongside `audience`, not as a rename. Existing `OAUTH_AUDIENCE` / `oauth_audience` configurations will keep working.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Set your credentials via environment variables (see [Configuration](#configuration)) or pass them directly:
+Configure the client via environment variables (see [Configuration](#configuration)) or pass values directly. The Quick Start snippet needs more than credentials at runtime — at minimum a `base_url` / `GUNDI_API_BASE_URL`, an `OAUTH_CLIENT_ID`, and either an `OAUTH_ISSUER` or `oauth_token_url`. Example with kwargs:
 
 ```python
 client = GundiClient(
@@ -92,8 +92,7 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `GUNDI_PASSWORD` | Your Gundi password — required for password grant | — |
 | `OAUTH_CLIENT_ID` | OAuth client ID | — |
 | `OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
-| `OAUTH_ISSUER` | OAuth issuer base URL; token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. **Do not include a trailing slash** — the value is not stripped and a trailing slash will produce a double-slash in the derived URL. | — |
-| `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. Takes precedence over the value derived from `OAUTH_ISSUER` when set explicitly in the environment. | — |
+| `OAUTH_ISSUER` | OAuth issuer base URL; the token URL is derived from it as `{OAUTH_ISSUER}/protocol/openid-connect/token`. **Do not include a trailing slash** — the value is not stripped and a trailing slash will produce a double-slash in the derived URL. There is no `OAUTH_TOKEN_URL` env var; use the `oauth_token_url` kwarg if you need to override the derivation. | — |
 | `OAUTH_AUDIENCE` | OAuth audience | — |
 | `OAUTH_SCOPE` | OAuth scope | `openid` |
 | `GUNDI_API_BASE_URL` | Gundi API base URL | — |
@@ -112,7 +111,7 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `password` | `GUNDI_PASSWORD` | Gundi password |
 | `oauth_client_id` | `OAUTH_CLIENT_ID` | OAuth client ID |
 | `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | OAuth client secret |
-| `oauth_token_url` | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL |
+| `oauth_token_url` | — (derived from `OAUTH_ISSUER`) | Full OAuth token endpoint URL. No direct env-var counterpart — set `OAUTH_ISSUER` to have the token URL derived, or pass this kwarg to override. |
 | `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience |
 | `oauth_scope` | `OAUTH_SCOPE` | OAuth scope |
 | `max_http_retries` | — | Max HTTP retries (default `5`) |

--- a/README.md
+++ b/README.md
@@ -15,13 +15,18 @@ pip install gundi-client-v2
 ## Quick Start
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient
 
-async with GundiClient() as client:
-    connection = await client.get_connection_details(
-        integration_id="your-integration-uuid"
-    )
-    print(connection.provider.name)
+async def main():
+    async with GundiClient() as client:
+        connection = await client.get_connection_details(
+            integration_id="your-integration-uuid"
+        )
+        print(connection.provider.name)
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 Set your credentials via environment variables (see [Configuration](#configuration)) or pass them directly:
@@ -40,62 +45,88 @@ client = GundiClient(
 ### End-to-End: List, Get Key, Send Data
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient, GundiDataSenderClient
 
-async with GundiClient() as client:
-    # 1. List integrations and find yours by name
-    my_integration = None
-    async for i in client.get_integrations():
-        if i.name == "My Integration":
-            my_integration = i
-            break
+async def main():
+    async with GundiClient() as client:
+        # 1. List integrations and find yours by name
+        my_integration = None
+        async for i in client.get_integrations():
+            if i.name == "My Integration":
+                my_integration = i
+                break
+        if my_integration is None:
+            raise RuntimeError("Integration 'My Integration' not found")
 
-    # 2. Get the API key for that integration
-    api_key = await client.get_integration_api_key(
-        integration_id=str(my_integration.id)
-    )
+        # 2. Get the API key for that integration
+        api_key = await client.get_integration_api_key(
+            integration_id=str(my_integration.id)
+        )
 
-# 3. Use the API key to send data
-sender = GundiDataSenderClient(integration_api_key=api_key)
-await sender.post_events(data=[
-    {
-        "title": "Animal Detected",
-        "event_type": "wildlife_sighting_rep",
-        "recorded_at": "2024-01-15T10:30:00Z",
-        "location": {"lat": -1.286, "lon": 36.817},
-        "event_details": {"species": "lion"},
-    }
-])
+    # 3. Use the API key to send data
+    sender = GundiDataSenderClient(integration_api_key=api_key)
+    await sender.post_events(data=[
+        {
+            "title": "Animal Detected",
+            "event_type": "wildlife_sighting_rep",
+            "recorded_at": "2024-01-15T10:30:00Z",
+            "location": {"lat": -1.286, "lon": 36.817},
+            "event_details": {"species": "lion"},
+        }
+    ])
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Configuration
 
-All settings can be provided as environment variables or keyword arguments to the client constructor.
+Settings can be provided as **environment variables** or **constructor keyword arguments**. The two namespaces differ in several places — see the tables below.
 
-### Developer Authentication
+### Environment variables
 
-| Variable | Description | Required |
+| Env var | Description | Default |
 |---|---|---|
-| `GUNDI_USERNAME` | Your Gundi username (email) | Yes (for password auth) |
-| `GUNDI_PASSWORD` | Your Gundi password | Yes (for password auth) |
-
-### Service Authentication
-
-| Variable | Description | Required |
-|---|---|---|
-| `OAUTH_CLIENT_ID` | OAuth client ID | Yes |
-| `OAUTH_CLIENT_SECRET` | OAuth client secret | Yes (for client credentials auth) |
-
-### Common
-
-| Variable | Description | Default |
-|---|---|---|
-| `OAUTH_ISSUER` | OAuth issuer URL (token URL is derived as `{issuer}/protocol/openid-connect/token`) | — |
+| `GUNDI_USERNAME` | Your Gundi username (email) — required for password grant | — |
+| `GUNDI_PASSWORD` | Your Gundi password — required for password grant | — |
+| `OAUTH_CLIENT_ID` | OAuth client ID | — |
+| `OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
+| `OAUTH_ISSUER` | OAuth issuer base URL; token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. **Do not include a trailing slash** — the value is not stripped and a trailing slash will produce a double-slash in the derived URL. | — |
+| `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. Takes precedence over the value derived from `OAUTH_ISSUER` when set explicitly in the environment. | — |
 | `OAUTH_AUDIENCE` | OAuth audience | — |
+| `OAUTH_SCOPE` | OAuth scope | `openid` |
 | `GUNDI_API_BASE_URL` | Gundi API base URL | — |
-| `SENSORS_API_BASE_URL` | Sensors/routing API base URL | — |
+| `SENSORS_API_BASE_URL` | Sensors/routing API base URL (used by `GundiDataSenderClient`) | — |
 | `GUNDI_API_SSL_VERIFY` | Verify SSL certificates | `true` |
-| `LOG_LEVEL` | Logging level | `INFO` |
+| `LOG_LEVEL` | Logging level (env-only) | `INFO` |
+| `GUNDI_CLIENT_ENVFILE` | Path to a `.env` file to load (env-only; defaults to `.env` in cwd) | — |
+
+### GundiClient constructor kwargs
+
+| Kwarg | Corresponding env var | Description |
+|---|---|---|
+| `base_url` | `GUNDI_API_BASE_URL` | Gundi API base URL |
+| `use_ssl` | `GUNDI_API_SSL_VERIFY` | Verify SSL certificates |
+| `username` | `GUNDI_USERNAME` | Gundi username |
+| `password` | `GUNDI_PASSWORD` | Gundi password |
+| `oauth_client_id` | `OAUTH_CLIENT_ID` | OAuth client ID |
+| `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | OAuth client secret |
+| `oauth_token_url` | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL |
+| `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience |
+| `oauth_scope` | `OAUTH_SCOPE` | OAuth scope |
+| `max_http_retries` | — | Max HTTP retries (default `5`) |
+| `connect_timeout` | — | Connect timeout in seconds (default `3.1`) |
+| `data_timeout` | — | Data timeout in seconds (default `20`) |
+
+> **Note:** `OAUTH_ISSUER` has no constructor kwarg counterpart. Set `oauth_token_url` directly when constructing a client programmatically.
+
+### GundiDataSenderClient constructor kwargs
+
+| Kwarg | Corresponding env var | Description |
+|---|---|---|
+| `integration_api_key` | — | API key for the integration (required) |
+| `sensors_api_base_url` | `SENSORS_API_BASE_URL` | Sensors/routing API base URL |
 
 ## Authentication
 
@@ -105,7 +136,7 @@ The client supports two authentication modes:
 
 **Client credentials grant (for services)** — Provide `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. This is used by internal backend services.
 
-> **Note:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) and `keycloak_*` constructor kwargs are still accepted for backward compatibility.
+> **Backward compatibility:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) are still accepted as fallbacks for the corresponding `OAUTH_*` env vars. Three legacy constructor kwargs are also still accepted: `keycloak_client_id`, `keycloak_client_secret`, and `keycloak_audience`. There is no `keycloak_issuer` constructor kwarg — use `oauth_token_url` instead.
 
 If both are configured, password grant takes precedence. Contact the Gundi team for credentials.
 
@@ -114,58 +145,72 @@ If both are configured, password grant takes precedence. Contact the Gundi team 
 Use `GundiClient` as an async context manager to query the Gundi API.
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient
 
-async with GundiClient() as client:
-    # List integrations you have access to (async generator — paginated)
-    async for integration in client.get_integrations():
-        print(integration.name, integration.id)
+async def main():
+    async with GundiClient() as client:
+        # List integrations you have access to (async generator — paginated)
+        async for integration in client.get_integrations():
+            print(integration.name, integration.id)
 
-    # Find an integration by name and get its API key
-    target = None
-    async for i in client.get_integrations():
-        if i.name == "My Integration":
-            target = i
-            break
-    api_key = await client.get_integration_api_key(
-        integration_id=str(target.id)
-    )
+        # Find an integration by name and get its API key
+        target = None
+        async for i in client.get_integrations():
+            if i.name == "My Integration":
+                target = i
+                break
+        if target is None:
+            raise RuntimeError("Integration 'My Integration' not found")
+        api_key = await client.get_integration_api_key(
+            integration_id=str(target.id)
+        )
 
-    # List connections
-    connections = await client.get_connections()
+        # List connections
+        connections = await client.get_connections()
 
-    # Get connection details
-    connection = await client.get_connection_details(
-        integration_id="some-uuid"
-    )
+        # Get connection details
+        connection = await client.get_connection_details(
+            integration_id="some-uuid"
+        )
 
-    # Get integration details
-    integration = await client.get_integration_details(
-        integration_id="some-uuid"
-    )
+        # Get integration details
+        integration = await client.get_integration_details(
+            integration_id="some-uuid"
+        )
 
-    # Get route details
-    route = await client.get_route_details(route_id="some-uuid")
+        # Get route details
+        route = await client.get_route_details(route_id="some-uuid")
 
-    # Query traces
-    traces = await client.get_traces(params={"object_id": "some-uuid"})
+        # Query traces
+        traces = await client.get_traces(params={"object_id": "some-uuid"})
 
-    # Register an integration type
-    integration_type = await client.register_integration_type(
-        data={"name": "MyIntegration", "value": "my_integration"}
-    )
+        # Register an integration type
+        integration_type = await client.register_integration_type(
+            data={"name": "MyIntegration", "value": "my_integration"}
+        )
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 You can also create a client without a context manager and close it manually:
 
 ```python
-client = GundiClient()
-try:
-    connection = await client.get_connection_details(
-        integration_id="some-uuid"
-    )
-finally:
-    await client.close()
+import asyncio
+from gundi_client_v2 import GundiClient
+
+async def main():
+    client = GundiClient()
+    try:
+        connection = await client.get_connection_details(
+            integration_id="some-uuid"
+        )
+    finally:
+        await client.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Usage: GundiDataSenderClient
@@ -173,54 +218,59 @@ finally:
 Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials.
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiDataSenderClient
 
-sender = GundiDataSenderClient(integration_api_key="your-api-key")
+async def main():
+    sender = GundiDataSenderClient(integration_api_key="your-api-key")
 
-# Post observations
-await sender.post_observations(data=[
-    {
-        "source": "device-123",
-        "source_name": "GPS Tracker",
-        "type": "tracking-device",
-        "recorded_at": "2024-01-15T10:30:00Z",
-        "location": {"lat": -1.286389, "lon": 36.817223},
-    }
-])
+    # Post observations
+    await sender.post_observations(data=[
+        {
+            "source": "device-123",
+            "source_name": "GPS Tracker",
+            "type": "tracking-device",
+            "recorded_at": "2024-01-15T10:30:00Z",
+            "location": {"lat": -1.286389, "lon": 36.817223},
+        }
+    ])
 
-# Post events
-await sender.post_events(data=[
-    {
-        "title": "Animal Detected",
-        "event_type": "wildlife_sighting_rep",
-        "recorded_at": "2024-01-15T10:30:00Z",
-        "location": {"lat": -1.286389, "lon": 36.817223},
-        "event_details": {"species": "lion"},
-    }
-])
+    # Post events
+    await sender.post_events(data=[
+        {
+            "title": "Animal Detected",
+            "event_type": "wildlife_sighting_rep",
+            "recorded_at": "2024-01-15T10:30:00Z",
+            "location": {"lat": -1.286389, "lon": 36.817223},
+            "event_details": {"species": "lion"},
+        }
+    ])
 
-# Post messages
-await sender.post_messages(data=[
-    {
-        "sender": "ranger-radio-1",
-        "recipients": ["hq@example.org"],
-        "text": "All clear at checkpoint.",
-        "recorded_at": "2024-01-15T10:30:00Z",
-    }
-])
+    # Post messages
+    await sender.post_messages(data=[
+        {
+            "sender": "ranger-radio-1",
+            "recipients": ["hq@example.org"],
+            "text": "All clear at checkpoint.",
+            "recorded_at": "2024-01-15T10:30:00Z",
+        }
+    ])
 
-# Update an event
-await sender.update_event(
-    event_id="event-uuid",
-    data={"title": "Updated Title"},
-)
-
-# Post event attachments
-with open("photo.jpg", "rb") as f:
-    await sender.post_event_attachments(
+    # Update an event
+    await sender.update_event(
         event_id="event-uuid",
-        attachments=[("photo.jpg", f.read())],
+        data={"title": "Updated Title"},
     )
+
+    # Post event attachments
+    with open("photo.jpg", "rb") as f:
+        await sender.post_event_attachments(
+            event_id="event-uuid",
+            attachments=[("photo.jpg", f.read())],
+        )
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## Error Handling
@@ -228,22 +278,27 @@ with open("photo.jpg", "rb") as f:
 The client raises specific exceptions for different failure modes:
 
 ```python
+import asyncio
 from gundi_client_v2 import GundiClient, AuthenticationError, GundiAPIError, GundiClientError
 
-async with GundiClient() as client:
-    try:
-        connection = await client.get_connection_details(
-            integration_id="some-uuid"
-        )
-    except AuthenticationError as e:
-        # OAuth token request failed (bad credentials, expired, etc.)
-        print(f"Auth failed: {e}")
-    except GundiAPIError as e:
-        # Non-2xx response from the API
-        print(f"API error {e.status_code}: {e.detail}")
-    except GundiClientError as e:
-        # Base exception for all client errors
-        print(f"Client error: {e}")
+async def main():
+    async with GundiClient() as client:
+        try:
+            connection = await client.get_connection_details(
+                integration_id="some-uuid"
+            )
+        except AuthenticationError as e:
+            # OAuth token request failed (bad credentials, expired, etc.)
+            print(f"Auth failed: {e}")
+        except GundiAPIError as e:
+            # Non-2xx response from the API
+            print(f"API error {e.status_code}: {e.detail}")
+        except GundiClientError as e:
+            # Base exception for all client errors
+            print(f"Client error: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The client resolves the OAuth token endpoint in this order:
 
 1. **`oauth_token_url` (kwarg) / `OAUTH_TOKEN_URL` (env)** — used as-is when set.
 2. **`oauth_issuer` (kwarg) / `OAUTH_ISSUER` (env)** — the client fetches `{issuer}/.well-known/openid-configuration` (OIDC discovery) and uses its `token_endpoint`. Result is cached for the process lifetime; call `gundi_client_v2.auth.clear_discovery_cache()` to invalidate.
-3. **Neither set** — `AuthenticationError("No token URL configured.")` is raised on the first auth attempt.
+3. **Neither set** — `AuthenticationError("No token URL configured. Set oauth_token_url or oauth_issuer.")` is raised on the first auth attempt.
 
 OIDC discovery works for any compliant IdP (Keycloak, Auth0, Okta, …). Configure `OAUTH_ISSUER` and the token endpoint is found automatically.
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,251 @@
-# Gundi Client
-## Introduction
-[Gundi](https://www.earthranger.com/), a.k.a "The Portal" is a platform to manage integrations.
-The gundi-client is an async python client to interact with Gundi's REST API.
+# Gundi Client v2
+
+An async Python client for the [Gundi](https://www.earthranger.com/) API. Gundi (a.k.a. "The Portal") is a platform for managing wildlife conservation integrations — connecting sensors, cameras, and other data sources to analytical platforms like EarthRanger.
+
+This library provides two clients:
+- **`GundiClient`** — query connections, integrations, routes, and traces
+- **`GundiDataSenderClient`** — post observations, events, and messages
 
 ## Installation
-```
+
+```bash
 pip install gundi-client-v2
 ```
 
-## Usage
+## Quick Start
 
-```
+```python
 from gundi_client_v2 import GundiClient
-import httpx
 
-# You can use it as an async context-managed client
 async with GundiClient() as client:
-   try:
     connection = await client.get_connection_details(
-        integration_id="some-integration-uuid"
+        integration_id="your-integration-uuid"
     )
-    except httpx.RequestError as e:
-        logger.exception("Request Error")   
-        ...
-    except httpx.TimeoutException as e:
-        logger.exception("Request timed out")
-        ...
-    except httpx.HTTPStatusError as e:
-        logger.exception("Response returned error")
-    else:
-        for integration in connection.destinations:  
-            ...
-   ...
+    print(connection.provider.name)
+```
 
-# Or create an instance and close the client explicitly later
+Set your credentials via environment variables (see [Configuration](#configuration)) or pass them directly:
+
+```python
+client = GundiClient(
+    username="you@example.com",
+    password="your-password",
+    oauth_client_id="your-client-id",
+    oauth_audience="your-audience",
+    oauth_token_url="https://auth.example.com/.../token",
+    base_url="https://api.example.com",
+)
+```
+
+### End-to-End: List, Get Key, Send Data
+
+```python
+from gundi_client_v2 import GundiClient, GundiDataSenderClient
+
+async with GundiClient() as client:
+    # 1. List integrations and find yours by name
+    my_integration = None
+    async for i in client.get_integrations():
+        if i.name == "My Integration":
+            my_integration = i
+            break
+
+    # 2. Get the API key for that integration
+    api_key = await client.get_integration_api_key(
+        integration_id=str(my_integration.id)
+    )
+
+# 3. Use the API key to send data
+sender = GundiDataSenderClient(integration_api_key=api_key)
+await sender.post_events(data=[
+    {
+        "title": "Animal Detected",
+        "event_type": "wildlife_sighting_rep",
+        "recorded_at": "2024-01-15T10:30:00Z",
+        "location": {"lat": -1.286, "lon": 36.817},
+        "event_details": {"species": "lion"},
+    }
+])
+```
+
+## Configuration
+
+All settings can be provided as environment variables or keyword arguments to the client constructor.
+
+### Developer Authentication
+
+| Variable | Description | Required |
+|---|---|---|
+| `GUNDI_USERNAME` | Your Gundi username (email) | Yes (for password auth) |
+| `GUNDI_PASSWORD` | Your Gundi password | Yes (for password auth) |
+
+### Service Authentication
+
+| Variable | Description | Required |
+|---|---|---|
+| `OAUTH_CLIENT_ID` | OAuth client ID | Yes |
+| `OAUTH_CLIENT_SECRET` | OAuth client secret | Yes (for client credentials auth) |
+
+### Common
+
+| Variable | Description | Default |
+|---|---|---|
+| `OAUTH_ISSUER` | OAuth issuer URL (token URL is derived as `{issuer}/protocol/openid-connect/token`) | — |
+| `OAUTH_AUDIENCE` | OAuth audience | — |
+| `GUNDI_API_BASE_URL` | Gundi API base URL | — |
+| `SENSORS_API_BASE_URL` | Sensors/routing API base URL | — |
+| `GUNDI_API_SSL_VERIFY` | Verify SSL certificates | `true` |
+| `LOG_LEVEL` | Logging level | `INFO` |
+
+## Authentication
+
+The client supports two authentication modes:
+
+**Password grant (for developers)** — Provide `GUNDI_USERNAME` and `GUNDI_PASSWORD` along with `OAUTH_CLIENT_ID`. This is the recommended approach for external developers.
+
+**Client credentials grant (for services)** — Provide `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. This is used by internal backend services.
+
+> **Note:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) and `keycloak_*` constructor kwargs are still accepted for backward compatibility.
+
+If both are configured, password grant takes precedence. Contact the Gundi team for credentials.
+
+## Usage: GundiClient
+
+Use `GundiClient` as an async context manager to query the Gundi API.
+
+```python
+from gundi_client_v2 import GundiClient
+
+async with GundiClient() as client:
+    # List integrations you have access to (async generator — paginated)
+    async for integration in client.get_integrations():
+        print(integration.name, integration.id)
+
+    # Find an integration by name and get its API key
+    target = None
+    async for i in client.get_integrations():
+        if i.name == "My Integration":
+            target = i
+            break
+    api_key = await client.get_integration_api_key(
+        integration_id=str(target.id)
+    )
+
+    # List connections
+    connections = await client.get_connections()
+
+    # Get connection details
+    connection = await client.get_connection_details(
+        integration_id="some-uuid"
+    )
+
+    # Get integration details
+    integration = await client.get_integration_details(
+        integration_id="some-uuid"
+    )
+
+    # Get route details
+    route = await client.get_route_details(route_id="some-uuid")
+
+    # Query traces
+    traces = await client.get_traces(params={"object_id": "some-uuid"})
+
+    # Register an integration type
+    integration_type = await client.register_integration_type(
+        data={"name": "MyIntegration", "value": "my_integration"}
+    )
+```
+
+You can also create a client without a context manager and close it manually:
+
+```python
 client = GundiClient()
 try:
-    response = await client.get_connection_details(
-        integration_id="some-integration-uuid"
+    connection = await client.get_connection_details(
+        integration_id="some-uuid"
     )
-    except httpx.RequestError as e:
-        logger.exception("Request Error")   
-        ...
-    except httpx.TimeoutException as e:
-        logger.exception("Request timed out")
-        ...
-    except httpx.HTTPStatusError as e:
-        logger.exception("Response returned error")
-    else:
-        for integration in connection.destinations:
-            ...
-   ...
-   await client.close()  # Close the session used to send requests to Gundi
+finally:
+    await client.close()
 ```
+
+## Usage: GundiDataSenderClient
+
+Use `GundiDataSenderClient` to post data through the Gundi sensors/routing API. This client authenticates with an integration API key rather than user credentials.
+
+```python
+from gundi_client_v2 import GundiDataSenderClient
+
+sender = GundiDataSenderClient(integration_api_key="your-api-key")
+
+# Post observations
+await sender.post_observations(data=[
+    {
+        "source": "device-123",
+        "source_name": "GPS Tracker",
+        "type": "tracking-device",
+        "recorded_at": "2024-01-15T10:30:00Z",
+        "location": {"lat": -1.286389, "lon": 36.817223},
+    }
+])
+
+# Post events
+await sender.post_events(data=[
+    {
+        "title": "Animal Detected",
+        "event_type": "wildlife_sighting_rep",
+        "recorded_at": "2024-01-15T10:30:00Z",
+        "location": {"lat": -1.286389, "lon": 36.817223},
+        "event_details": {"species": "lion"},
+    }
+])
+
+# Post messages
+await sender.post_messages(data=[
+    {
+        "sender": "ranger-radio-1",
+        "recipients": ["hq@example.org"],
+        "text": "All clear at checkpoint.",
+        "recorded_at": "2024-01-15T10:30:00Z",
+    }
+])
+
+# Update an event
+await sender.update_event(
+    event_id="event-uuid",
+    data={"title": "Updated Title"},
+)
+
+# Post event attachments
+with open("photo.jpg", "rb") as f:
+    await sender.post_event_attachments(
+        event_id="event-uuid",
+        attachments=[("photo.jpg", f.read())],
+    )
+```
+
+## Error Handling
+
+The client raises specific exceptions for different failure modes:
+
+```python
+from gundi_client_v2 import GundiClient, AuthenticationError, GundiAPIError, GundiClientError
+
+async with GundiClient() as client:
+    try:
+        connection = await client.get_connection_details(
+            integration_id="some-uuid"
+        )
+    except AuthenticationError as e:
+        # OAuth token request failed (bad credentials, expired, etc.)
+        print(f"Auth failed: {e}")
+    except GundiAPIError as e:
+        # Non-2xx response from the API
+        print(f"API error {e.status_code}: {e.detail}")
+    except GundiClientError as e:
+        # Base exception for all client errors
+        print(f"Client error: {e}")
+```
+
+## License
+
+Apache 2.0

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
 | `OAUTH_ISSUER` | OIDC issuer URL. When set without `OAUTH_TOKEN_URL`, the token endpoint is discovered at runtime from `{OAUTH_ISSUER}/.well-known/openid-configuration`. A trailing slash is normalized. | — |
 | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, overrides OIDC discovery from `OAUTH_ISSUER`. | — |
-| `OAUTH_AUDIENCE` | OAuth audience | — |
+| `OAUTH_AUDIENCE` | OAuth audience. Sent to the token endpoint when set. Required by some IdPs (e.g. Auth0 won't issue a usable API access token without it); ignored by others (Keycloak password grant). | — |
 | `OAUTH_SCOPE` | OAuth scope | `openid` |
 | `GUNDI_API_BASE_URL` | Gundi API base URL | — |
 | `SENSORS_API_BASE_URL` | Sensors/routing API base URL (used by `GundiDataSenderClient`) | — |
@@ -118,7 +118,7 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | OAuth client secret |
 | `oauth_token_url` | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, used as-is. |
 | `oauth_issuer` | `OAUTH_ISSUER` | OIDC issuer URL. When set without `oauth_token_url`, the token endpoint is discovered via OIDC discovery. |
-| `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience |
+| `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience. IdP-dependent — required for Auth0, optional for Keycloak password grant. |
 | `oauth_scope` | `OAUTH_SCOPE` | OAuth scope |
 | `max_http_retries` | — | Max HTTP retries (default `5`) |
 | `connect_timeout` | — | Connect timeout in seconds (default `3.1`) |
@@ -148,6 +148,15 @@ The client resolves the OAuth token endpoint in this order:
 3. **Neither set** — `AuthenticationError("No token URL configured.")` is raised on the first auth attempt.
 
 OIDC discovery works for any compliant IdP (Keycloak, Auth0, Okta, …). Configure `OAUTH_ISSUER` and the token endpoint is found automatically.
+
+### Audience
+
+`OAUTH_AUDIENCE` is sent to the token endpoint when configured. Whether it is required depends on the IdP:
+
+- **Auth0** — required. Without `audience`, Auth0 issues an opaque token that cannot authorize API requests.
+- **Keycloak** — optional. The password grant ignores it; UMA flows use it for scope matching.
+
+The parameter name `audience` reflects the Auth0/Keycloak convention. The OAuth 2.0 / OIDC standard equivalent is `resource` (RFC 8707, *Resource Indicators*). If we add support for IdPs that strictly require `resource` instead, it will be introduced as a `resource` kwarg alongside `audience`, not as a rename. Existing `OAUTH_AUDIENCE` / `oauth_audience` configurations will keep working.
 
 > **Backward compatibility:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) are still accepted as fallbacks for the corresponding `OAUTH_*` env vars. Three legacy constructor kwargs are also still accepted: `keycloak_client_id`, `keycloak_client_secret`, and `keycloak_audience`. There is no `keycloak_issuer` constructor kwarg — use `oauth_token_url` or `oauth_issuer` instead.
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -4,16 +4,19 @@ GUNDI_USERNAME=your-username
 GUNDI_PASSWORD=your-password
 GUNDI_INTEGRATION_NAME="Your Integration Name"
 
-# OAuth (password grant). Use OAUTH_ISSUER or the full OAUTH_TOKEN_URL.
-OAUTH_ISSUER=https://cdip-auth.pamdas.org/auth/realms/cdip-dev
-OAUTH_CLIENT_ID=cdip-oauth2
-OAUTH_AUDIENCE=cdip-admin-portal
-# Optional: full token URL instead of OAUTH_ISSUER
-#OAUTH_TOKEN_URL=https://cdip-auth.pamdas.org/auth/realms/cdip-dev/protocol/openid-connect/token
+# OAuth (password grant). Set OAUTH_ISSUER and the library derives the token endpoint
+# as {OAUTH_ISSUER}/protocol/openid-connect/token. Alternatively, the example script
+# send_observations.py also accepts OAUTH_TOKEN_URL directly and passes it as the
+# oauth_token_url kwarg to GundiClient (the library does not read OAUTH_TOKEN_URL itself).
+OAUTH_ISSUER=https://auth.example.com/realms/your-realm
+OAUTH_CLIENT_ID=your-oauth-client-id
+OAUTH_AUDIENCE=your-oauth-audience
+# Optional (read only by send_observations.py): explicit token endpoint URL.
+#OAUTH_TOKEN_URL=https://auth.example.com/realms/your-realm/protocol/openid-connect/token
 
-# API base URLs (optional; defaults depend on deployment)
-GUNDI_API_BASE_URL=https://api.stage.gundiservice.org
-SENSORS_API_BASE_URL=https://sensors.api.stage.gundiservice.org
+# API base URLs (required for the example to function)
+GUNDI_API_BASE_URL=https://api.example.com
+SENSORS_API_BASE_URL=https://sensors.api.example.com
 
 # Optional
 # GUNDI_API_SSL_VERIFY=true

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -21,7 +21,7 @@
 #       GUNDI_USERNAME, GUNDI_PASSWORD,
 #       OAUTH_CLIENT_ID, OAUTH_ISSUER,
 #       GUNDI_API_BASE_URL
-#       (requires gundi-client-v2 >= 2.6.0)
+#       (requires gundi-client-v2 >= 3.0.0)
 #
 # OAUTH_AUDIENCE is conditional for ALL examples: required by some IdPs
 # (e.g. Auth0), ignored by Keycloak password grant.
@@ -45,7 +45,7 @@ OAUTH_AUDIENCE=your-oauth-audience
 #   - OAUTH_ISSUER:    the library will discover the token endpoint via
 #                      {OAUTH_ISSUER}/.well-known/openid-configuration
 #                      (used by list_connections_discovery.py;
-#                       requires gundi-client-v2 >= 2.6.0)
+#                       requires gundi-client-v2 >= 3.0.0)
 #   - OAUTH_TOKEN_URL: the explicit token endpoint URL
 #                      (used by the other examples)
 OAUTH_ISSUER=https://auth.example.com/realms/your-realm

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -10,6 +10,8 @@ GUNDI_INTEGRATION_NAME="Your Integration Name"
 #   - OAUTH_TOKEN_URL: the explicit token endpoint URL
 OAUTH_ISSUER=https://auth.example.com/realms/your-realm
 OAUTH_CLIENT_ID=your-oauth-client-id
+# Required by some IdPs (e.g., Auth0 won't issue a usable API access token
+# without it); ignored by others (Keycloak password grant). Set if needed.
 OAUTH_AUDIENCE=your-oauth-audience
 # Optional: explicit token endpoint URL (overrides OIDC discovery from OAUTH_ISSUER)
 #OAUTH_TOKEN_URL=https://auth.example.com/realms/your-realm/protocol/openid-connect/token

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,22 +1,57 @@
 # Copy this file to .env and fill in your values.
-# Required for examples (e.g. send_observations.py)
+#
+# Which vars each example needs:
+#
+#   send_observations.py                       — password grant + sender
+#       GUNDI_USERNAME, GUNDI_PASSWORD,
+#       OAUTH_CLIENT_ID, OAUTH_TOKEN_URL (or OAUTH_ISSUER),
+#       GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
+#       GUNDI_INTEGRATION_NAME
+#
+#   list_connections_client_credentials.py     — client_credentials grant
+#       OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_TOKEN_URL,
+#       GUNDI_API_BASE_URL
+#
+#   list_connections_password_grant.py         — password grant
+#       GUNDI_USERNAME, GUNDI_PASSWORD,
+#       OAUTH_CLIENT_ID, OAUTH_TOKEN_URL,
+#       GUNDI_API_BASE_URL
+#
+#   list_connections_discovery.py              — password grant + OIDC discovery
+#       GUNDI_USERNAME, GUNDI_PASSWORD,
+#       OAUTH_CLIENT_ID, OAUTH_ISSUER,
+#       GUNDI_API_BASE_URL
+#       (requires gundi-client-v2 >= 2.6.0)
+#
+# OAUTH_AUDIENCE is conditional for ALL examples: required by some IdPs
+# (e.g. Auth0), ignored by Keycloak password grant.
+
+# User credentials (password-grant examples + send_observations.py)
 GUNDI_USERNAME=your-username
 GUNDI_PASSWORD=your-password
+
+# Only used by send_observations.py
 GUNDI_INTEGRATION_NAME="Your Integration Name"
 
-# OAuth (password grant). Configure ONE of:
-#   - OAUTH_ISSUER: the library will discover the token endpoint via
-#     {OAUTH_ISSUER}/.well-known/openid-configuration (OIDC discovery)
-#   - OAUTH_TOKEN_URL: the explicit token endpoint URL
-OAUTH_ISSUER=https://auth.example.com/realms/your-realm
+# OAuth client config (all examples)
 OAUTH_CLIENT_ID=your-oauth-client-id
+# Required only by list_connections_client_credentials.py
+OAUTH_CLIENT_SECRET=your-oauth-client-secret
 # Required by some IdPs (e.g., Auth0 won't issue a usable API access token
 # without it); ignored by others (Keycloak password grant). Set if needed.
 OAUTH_AUDIENCE=your-oauth-audience
-# Optional: explicit token endpoint URL (overrides OIDC discovery from OAUTH_ISSUER)
+
+# Token endpoint — configure ONE of these:
+#   - OAUTH_ISSUER:    the library will discover the token endpoint via
+#                      {OAUTH_ISSUER}/.well-known/openid-configuration
+#                      (used by list_connections_discovery.py;
+#                       requires gundi-client-v2 >= 2.6.0)
+#   - OAUTH_TOKEN_URL: the explicit token endpoint URL
+#                      (used by the other examples)
+OAUTH_ISSUER=https://auth.example.com/realms/your-realm
 #OAUTH_TOKEN_URL=https://auth.example.com/realms/your-realm/protocol/openid-connect/token
 
-# API base URLs (required for the example to function)
+# API base URLs (required for the examples to function)
 GUNDI_API_BASE_URL=https://api.example.com
 SENSORS_API_BASE_URL=https://sensors.api.example.com
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -4,14 +4,14 @@ GUNDI_USERNAME=your-username
 GUNDI_PASSWORD=your-password
 GUNDI_INTEGRATION_NAME="Your Integration Name"
 
-# OAuth (password grant). Set OAUTH_ISSUER and the library derives the token endpoint
-# as {OAUTH_ISSUER}/protocol/openid-connect/token. Alternatively, the example script
-# send_observations.py also accepts OAUTH_TOKEN_URL directly and passes it as the
-# oauth_token_url kwarg to GundiClient (the library does not read OAUTH_TOKEN_URL itself).
+# OAuth (password grant). Configure ONE of:
+#   - OAUTH_ISSUER: the library will discover the token endpoint via
+#     {OAUTH_ISSUER}/.well-known/openid-configuration (OIDC discovery)
+#   - OAUTH_TOKEN_URL: the explicit token endpoint URL
 OAUTH_ISSUER=https://auth.example.com/realms/your-realm
 OAUTH_CLIENT_ID=your-oauth-client-id
 OAUTH_AUDIENCE=your-oauth-audience
-# Optional (read only by send_observations.py): explicit token endpoint URL.
+# Optional: explicit token endpoint URL (overrides OIDC discovery from OAUTH_ISSUER)
 #OAUTH_TOKEN_URL=https://auth.example.com/realms/your-realm/protocol/openid-connect/token
 
 # API base URLs (required for the example to function)

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to .env and fill in your values.
+# Required for examples (e.g. send_observations.py)
+GUNDI_USERNAME=your-username
+GUNDI_PASSWORD=your-password
+GUNDI_INTEGRATION_NAME="Your Integration Name"
+
+# OAuth (password grant). Use OAUTH_ISSUER or the full OAUTH_TOKEN_URL.
+OAUTH_ISSUER=https://cdip-auth.pamdas.org/auth/realms/cdip-dev
+OAUTH_CLIENT_ID=cdip-oauth2
+OAUTH_AUDIENCE=cdip-admin-portal
+# Optional: full token URL instead of OAUTH_ISSUER
+#OAUTH_TOKEN_URL=https://cdip-auth.pamdas.org/auth/realms/cdip-dev/protocol/openid-connect/token
+
+# API base URLs (optional; defaults depend on deployment)
+GUNDI_API_BASE_URL=https://api.stage.gundiservice.org
+SENSORS_API_BASE_URL=https://sensors.api.stage.gundiservice.org
+
+# Optional
+# GUNDI_API_SSL_VERIFY=true
+# LOG_LEVEL=INFO

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,9 +35,12 @@ Demonstrates:
   - `OAUTH_ISSUER` – OIDC issuer base URL (e.g. `https://auth.example.com/realms/my-realm`); the token endpoint is discovered automatically via `{OAUTH_ISSUER}/.well-known/openid-configuration`.
   - `OAUTH_TOKEN_URL` – explicit OAuth token endpoint URL (overrides OIDC discovery when set).
 
+**Conditional:**
+
+- `OAUTH_AUDIENCE` – OAuth audience. Required by some IdPs (e.g., Auth0 needs it to issue a usable API access token); ignored by others (Keycloak password grant). Set if your IdP requires it.
+
 **Optional:**
 
-- `OAUTH_AUDIENCE` – OAuth audience
 - `GUNDI_API_SSL_VERIFY` – set to `false` to skip SSL verification (default: `true`)
 
 **Setting up credentials with a `.env` file:**

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,47 @@
+# Gundi Client examples
+
+Simple examples for using the Gundi client with **username and password** credentials to access Gundi's API.
+
+## Setup
+
+From the repository root, install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+Then set the required environment variables (or pass credentials in code where the example allows it). You can copy `examples/.env.example` to `examples/.env` and fill in your values; the client will load `.env` from the current directory when run.
+
+## Examples
+
+### send_observations.py
+
+Demonstrates:
+
+1. Authenticating with a username and password
+2. Querying for integrations
+3. Selecting one integration by name and fetching its API key
+4. Using `GundiDataSenderClient` with that API key to send observations to Gundi
+
+**Required environment variables:**
+
+- `GUNDI_USERNAME` – your Gundi username
+- `GUNDI_PASSWORD` – your Gundi password
+- `GUNDI_INTEGRATION_NAME` – exact name of the integration to use for sending (e.g. the display name in the portal)
+
+**Optional (OAuth / API endpoints):**
+
+- `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`
+- `OAUTH_TOKEN_URL` – full OAuth token URL (overrides `OAUTH_ISSUER` if set)
+- `OAUTH_CLIENT_ID` – OAuth client id for the password grant
+- `OAUTH_AUDIENCE` – OAuth audience
+- `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
+- `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
+
+**Run:**
+
+```bash
+python examples/send_observations.py
+```
+
+Ensure the integration named in `GUNDI_INTEGRATION_NAME` exists in your Gundi deployment and has an API key configured.

--- a/examples/README.md
+++ b/examples/README.md
@@ -78,7 +78,7 @@ in all three — the variation is purely how the client is configured.
 |---|---|---|
 | `list_connections_client_credentials.py` | client_credentials grant (confidential client / M2M) | explicit `OAUTH_TOKEN_URL` |
 | `list_connections_password_grant.py` | password grant (public client / user-facing) | explicit `OAUTH_TOKEN_URL` |
-| `list_connections_discovery.py` | password grant + OIDC discovery (IdP-agnostic) | discovered from `OAUTH_ISSUER` — requires `gundi-client-v2 >= 2.6.0` |
+| `list_connections_discovery.py` | password grant + OIDC discovery (IdP-agnostic) | discovered from `OAUTH_ISSUER` — requires `gundi-client-v2 >= 3.0.0` |
 
 All three run the same way as `send_observations.py`:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -66,3 +66,30 @@ GUNDI_CLIENT_ENVFILE=examples/.env python examples/send_observations.py
 ```
 
 Ensure the integration named in `GUNDI_INTEGRATION_NAME` exists in your Gundi deployment and has an API key configured.
+
+### Listing connections — three auth paths
+
+These small scripts each list the Gundi connections accessible to the
+configured client, demonstrating the three OAuth2 auth paths the library
+supports. The library call is identical (`client.get_connections(...)`)
+in all three — the variation is purely how the client is configured.
+
+| Script | Auth path | Token URL source |
+|---|---|---|
+| `list_connections_client_credentials.py` | client_credentials grant (confidential client / M2M) | explicit `OAUTH_TOKEN_URL` |
+| `list_connections_password_grant.py` | password grant (public client / user-facing) | explicit `OAUTH_TOKEN_URL` |
+| `list_connections_discovery.py` | password grant + OIDC discovery (IdP-agnostic) | discovered from `OAUTH_ISSUER` — requires `gundi-client-v2 >= 2.6.0` |
+
+All three run the same way as `send_observations.py`:
+
+```bash
+cd examples
+python list_connections_<mode>.py
+```
+
+Each script also demonstrates passing `params={...}` to
+`get_connections` for server-side filtering — see the Gundi API docs for
+the available filter keys. The bundled example uses `params={"status": "healthy"}`.
+
+The required env vars for each are listed in the script's module
+docstring; `.env.example` also annotates which variables each example uses.

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,8 +32,8 @@ Demonstrates:
 - `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
 - `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
 - At least one of:
-  - `OAUTH_TOKEN_URL` – full OAuth token URL
-  - `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. Do not include a trailing slash.
+  - `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/realms/my-realm`); the library derives the token URL as `{OAUTH_ISSUER}/protocol/openid-connect/token`. Do not include a trailing slash.
+  - `OAUTH_TOKEN_URL` – Read by `send_observations.py` and passed as the `oauth_token_url` kwarg to `GundiClient`. The library itself only derives the token URL from `OAUTH_ISSUER`; setting `OAUTH_TOKEN_URL` in the environment without using this example script has no effect on the library.
 
 **Optional:**
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,8 +32,8 @@ Demonstrates:
 - `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
 - `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
 - At least one of:
-  - `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/realms/my-realm`); the library derives the token URL as `{OAUTH_ISSUER}/protocol/openid-connect/token`. Do not include a trailing slash.
-  - `OAUTH_TOKEN_URL` – Read by `send_observations.py` and passed as the `oauth_token_url` kwarg to `GundiClient`. The library itself only derives the token URL from `OAUTH_ISSUER`; setting `OAUTH_TOKEN_URL` in the environment without using this example script has no effect on the library.
+  - `OAUTH_ISSUER` – OIDC issuer base URL (e.g. `https://auth.example.com/realms/my-realm`); the token endpoint is discovered automatically via `{OAUTH_ISSUER}/.well-known/openid-configuration`.
+  - `OAUTH_TOKEN_URL` – explicit OAuth token endpoint URL (overrides OIDC discovery when set).
 
 **Optional:**
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ From the repository root, install the package in editable mode:
 pip install -e .
 ```
 
-Then set the required environment variables (or pass credentials in code where the example allows it). You can copy `examples/.env.example` to `examples/.env` and fill in your values; the client will load `.env` from the current directory when run.
+Then set the required environment variables (or pass credentials in code where the example allows it).
 
 ## Examples
 
@@ -28,20 +28,38 @@ Demonstrates:
 - `GUNDI_USERNAME` – your Gundi username
 - `GUNDI_PASSWORD` – your Gundi password
 - `GUNDI_INTEGRATION_NAME` – exact name of the integration to use for sending (e.g. the display name in the portal)
-
-**Optional (OAuth / API endpoints):**
-
-- `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`
-- `OAUTH_TOKEN_URL` – full OAuth token URL (overrides `OAUTH_ISSUER` if set)
-- `OAUTH_CLIENT_ID` – OAuth client id for the password grant
-- `OAUTH_AUDIENCE` – OAuth audience
+- `OAUTH_CLIENT_ID` – OAuth client ID for the password grant
 - `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
 - `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
+- At least one of:
+  - `OAUTH_TOKEN_URL` – full OAuth token URL
+  - `OAUTH_ISSUER` – OAuth issuer base URL (e.g. `https://auth.example.com/auth/realms/my-realm`); token URL is derived as `{OAUTH_ISSUER}/protocol/openid-connect/token`. Do not include a trailing slash.
 
-**Run:**
+**Optional:**
+
+- `OAUTH_AUDIENCE` – OAuth audience
+- `GUNDI_API_SSL_VERIFY` – set to `false` to skip SSL verification (default: `true`)
+
+**Setting up credentials with a `.env` file:**
+
+Copy `.env.example` to `.env` (in the `examples/` directory) and fill in your values:
 
 ```bash
-python examples/send_observations.py
+cp examples/.env.example examples/.env
+# edit examples/.env
+```
+
+The client loads `.env` from the **current working directory**, so run the script from the `examples/` directory:
+
+```bash
+cd examples
+python send_observations.py
+```
+
+Alternatively, run from the repo root and point to the file explicitly:
+
+```bash
+GUNDI_CLIENT_ENVFILE=examples/.env python examples/send_observations.py
 ```
 
 Ensure the integration named in `GUNDI_INTEGRATION_NAME` exists in your Gundi deployment and has an API key configured.

--- a/examples/list_connections_client_credentials.py
+++ b/examples/list_connections_client_credentials.py
@@ -1,0 +1,75 @@
+"""
+Example: list Gundi connections using the OAuth2 client_credentials grant
+(confidential client / service-to-service auth).
+
+# Required env vars:
+#   GUNDI_API_BASE_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_TOKEN_URL
+# Conditional:
+#   OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
+#                     API access token without it); ignored by Keycloak.
+
+Run from the examples/ directory (so the local .env is loaded):
+
+    cd examples
+    python list_connections_client_credentials.py
+"""
+
+import asyncio
+import json
+import os
+
+from gundi_client_v2 import GundiClient
+
+
+def _get_kwargs() -> dict:
+    """Validate required env vars; raise ValueError listing any that are missing."""
+    missing = []
+    kwargs = {}
+
+    if base_url := os.environ.get("GUNDI_API_BASE_URL"):
+        kwargs["base_url"] = base_url
+    else:
+        missing.append("GUNDI_API_BASE_URL")
+
+    if client_id := os.environ.get("OAUTH_CLIENT_ID"):
+        kwargs["oauth_client_id"] = client_id
+    else:
+        missing.append("OAUTH_CLIENT_ID")
+
+    if client_secret := os.environ.get("OAUTH_CLIENT_SECRET"):
+        kwargs["oauth_client_secret"] = client_secret
+    else:
+        missing.append("OAUTH_CLIENT_SECRET")
+
+    if token_url := os.environ.get("OAUTH_TOKEN_URL"):
+        kwargs["oauth_token_url"] = token_url
+    else:
+        missing.append("OAUTH_TOKEN_URL")
+
+    # Conditional — sent to the token endpoint when set; some IdPs require it.
+    if audience := os.environ.get("OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = audience
+
+    if missing:
+        raise ValueError(f"Missing required env vars: {', '.join(missing)}")
+    return kwargs
+
+
+async def main():
+    async with GundiClient(**_get_kwargs()) as client:
+        # `params` is forwarded to the underlying GET. The Gundi API supports
+        # several server-side filters on this endpoint:
+        #   status:        "healthy" | "unhealthy" | "disabled" | "needs_review"
+        #   provider_type: e.g. "earth_ranger", "traptagger"
+        #   destination_type, destination_url, destination_id (UUID), source_id (UUID), owner
+        # Results are paginated (default PAGE_SIZE=20); get_connections returns
+        # only the first page as a list.
+        connections = await client.get_connections(params={"status": "healthy"})
+        # `default=str` renders UUIDs and datetimes as their canonical string
+        # forms so json.dumps can serialize them. Output is pure JSON — pipe to
+        # `jq` for filtering: `python list_connections_client_credentials.py | jq '.[].provider.name'`
+        print(json.dumps([c.dict() for c in connections], default=str, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/list_connections_discovery.py
+++ b/examples/list_connections_discovery.py
@@ -1,0 +1,97 @@
+"""
+Example: list Gundi connections using the OAuth2 password grant with OIDC
+discovery — the library finds the token endpoint at
+{OAUTH_ISSUER}/.well-known/openid-configuration instead of needing
+OAUTH_TOKEN_URL configured explicitly.
+
+This is the IdP-agnostic path: it works against Keycloak, Auth0, Okta, and
+any other OIDC-compliant IdP with no code change — only OAUTH_ISSUER
+differs per deployment. After the Auth0 migration, point OAUTH_ISSUER at
+the Auth0 tenant and this same script keeps working.
+
+# Required env vars:
+#   GUNDI_API_BASE_URL, OAUTH_CLIENT_ID,
+#   GUNDI_USERNAME, GUNDI_PASSWORD,
+#   OAUTH_ISSUER
+# Conditional:
+#   OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
+#                     API access token without it); ignored by Keycloak.
+
+# Requires gundi-client-v2 >= 2.6.0 (OIDC discovery support).
+
+# Performance: the first auth incurs one extra HTTP request (the discovery
+# document); the resolved token endpoint is cached process-wide thereafter.
+# Call gundi_client_v2.auth.clear_discovery_cache() to invalidate.
+
+Run from the examples/ directory (so the local .env is loaded):
+
+    cd examples
+    python list_connections_discovery.py
+"""
+
+import asyncio
+import json
+import os
+
+from gundi_client_v2 import GundiClient
+
+
+def _get_kwargs() -> dict:
+    """Validate required env vars; raise ValueError listing any that are missing."""
+    missing = []
+    kwargs = {}
+
+    if base_url := os.environ.get("GUNDI_API_BASE_URL"):
+        kwargs["base_url"] = base_url
+    else:
+        missing.append("GUNDI_API_BASE_URL")
+
+    if client_id := os.environ.get("OAUTH_CLIENT_ID"):
+        kwargs["oauth_client_id"] = client_id
+    else:
+        missing.append("OAUTH_CLIENT_ID")
+
+    if username := os.environ.get("GUNDI_USERNAME"):
+        kwargs["username"] = username
+    else:
+        missing.append("GUNDI_USERNAME")
+
+    if password := os.environ.get("GUNDI_PASSWORD"):
+        kwargs["password"] = password
+    else:
+        missing.append("GUNDI_PASSWORD")
+
+    # NOTE: oauth_issuer (NOT oauth_token_url) — the library will resolve the
+    # token endpoint via OIDC discovery at runtime.
+    if issuer := os.environ.get("OAUTH_ISSUER"):
+        kwargs["oauth_issuer"] = issuer
+    else:
+        missing.append("OAUTH_ISSUER")
+
+    # Conditional — sent to the token endpoint when set; some IdPs require it.
+    if audience := os.environ.get("OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = audience
+
+    if missing:
+        raise ValueError(f"Missing required env vars: {', '.join(missing)}")
+    return kwargs
+
+
+async def main():
+    async with GundiClient(**_get_kwargs()) as client:
+        # `params` is forwarded to the underlying GET. The Gundi API supports
+        # several server-side filters on this endpoint:
+        #   status:        "healthy" | "unhealthy" | "disabled" | "needs_review"
+        #   provider_type: e.g. "earth_ranger", "traptagger"
+        #   destination_type, destination_url, destination_id (UUID), source_id (UUID), owner
+        # Results are paginated (default PAGE_SIZE=20); get_connections returns
+        # only the first page as a list.
+        connections = await client.get_connections(params={"status": "healthy"})
+        # `default=str` renders UUIDs and datetimes as their canonical string
+        # forms so json.dumps can serialize them. Output is pure JSON — pipe to
+        # `jq` for filtering: `python list_connections_discovery.py | jq '.[].provider.name'`
+        print(json.dumps([c.dict() for c in connections], default=str, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/list_connections_discovery.py
+++ b/examples/list_connections_discovery.py
@@ -17,7 +17,7 @@ the Auth0 tenant and this same script keeps working.
 #   OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
 #                     API access token without it); ignored by Keycloak.
 
-# Requires gundi-client-v2 >= 2.6.0 (OIDC discovery support).
+# Requires gundi-client-v2 >= 3.0.0 (OIDC discovery support).
 
 # Performance: the first auth incurs one extra HTTP request (the discovery
 # document); the resolved token endpoint is cached process-wide thereafter.

--- a/examples/list_connections_password_grant.py
+++ b/examples/list_connections_password_grant.py
@@ -1,0 +1,82 @@
+"""
+Example: list Gundi connections using the OAuth2 password grant
+(public client / user-facing developer auth).
+
+# Required env vars:
+#   GUNDI_API_BASE_URL, OAUTH_CLIENT_ID,
+#   GUNDI_USERNAME, GUNDI_PASSWORD,
+#   OAUTH_TOKEN_URL
+# Conditional:
+#   OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
+#                     API access token without it); ignored by Keycloak.
+
+Run from the examples/ directory (so the local .env is loaded):
+
+    cd examples
+    python list_connections_password_grant.py
+"""
+
+import asyncio
+import json
+import os
+
+from gundi_client_v2 import GundiClient
+
+
+def _get_kwargs() -> dict:
+    """Validate required env vars; raise ValueError listing any that are missing."""
+    missing = []
+    kwargs = {}
+
+    if base_url := os.environ.get("GUNDI_API_BASE_URL"):
+        kwargs["base_url"] = base_url
+    else:
+        missing.append("GUNDI_API_BASE_URL")
+
+    if client_id := os.environ.get("OAUTH_CLIENT_ID"):
+        kwargs["oauth_client_id"] = client_id
+    else:
+        missing.append("OAUTH_CLIENT_ID")
+
+    if username := os.environ.get("GUNDI_USERNAME"):
+        kwargs["username"] = username
+    else:
+        missing.append("GUNDI_USERNAME")
+
+    if password := os.environ.get("GUNDI_PASSWORD"):
+        kwargs["password"] = password
+    else:
+        missing.append("GUNDI_PASSWORD")
+
+    if token_url := os.environ.get("OAUTH_TOKEN_URL"):
+        kwargs["oauth_token_url"] = token_url
+    else:
+        missing.append("OAUTH_TOKEN_URL")
+
+    # Conditional — sent to the token endpoint when set; some IdPs require it.
+    if audience := os.environ.get("OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = audience
+
+    if missing:
+        raise ValueError(f"Missing required env vars: {', '.join(missing)}")
+    return kwargs
+
+
+async def main():
+    async with GundiClient(**_get_kwargs()) as client:
+        # `params` is forwarded to the underlying GET. The Gundi API supports
+        # several server-side filters on this endpoint:
+        #   status:        "healthy" | "unhealthy" | "disabled" | "needs_review"
+        #   provider_type: e.g. "earth_ranger", "traptagger"
+        #   destination_type, destination_url, destination_id (UUID), source_id (UUID), owner
+        # Results are paginated (default PAGE_SIZE=20); get_connections returns
+        # only the first page as a list.
+        connections = await client.get_connections(params={"status": "healthy"})
+        # `default=str` renders UUIDs and datetimes as their canonical string
+        # forms so json.dumps can serialize them. Output is pure JSON — pipe to
+        # `jq` for filtering: `python list_connections_password_grant.py | jq '.[].provider.name'`
+        print(json.dumps([c.dict() for c in connections], default=str, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -4,10 +4,14 @@ then use GundiDataSenderClient to send observations to Gundi.
 
 Set credentials via environment variables (recommended) or pass them in code.
 
-Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME,
-          OAUTH_CLIENT_ID, GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
-          and at least one of OAUTH_TOKEN_URL or OAUTH_ISSUER.
-Optional: OAUTH_AUDIENCE, GUNDI_API_SSL_VERIFY
+# Required (read by this script; one of OAUTH_ISSUER or OAUTH_TOKEN_URL must be set):
+#   GUNDI_USERNAME, GUNDI_PASSWORD,
+#   GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
+#   OAUTH_CLIENT_ID, OAUTH_AUDIENCE,
+#   OAUTH_ISSUER  (library derives the token URL as {issuer}/protocol/openid-connect/token)
+#     OR
+#   OAUTH_TOKEN_URL  (read by this script and passed as the oauth_token_url kwarg to GundiClient)
+# Optional: OAUTH_AUDIENCE, GUNDI_API_SSL_VERIFY
 
 Run from the examples/ directory (so the .env file in that directory is loaded):
 

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -1,0 +1,101 @@
+"""
+Example: Authenticate with username/password, get an integration's API key by name,
+then use GundiDataSenderClient to send observations to Gundi.
+
+Set credentials via environment variables (recommended) or pass them in code.
+Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME
+Optional: OAUTH_ISSUER (or OAUTH_TOKEN_URL), OAUTH_CLIENT_ID, OAUTH_AUDIENCE,
+          GUNDI_API_BASE_URL, SENSORS_API_BASE_URL
+"""
+
+import asyncio
+import os
+from datetime import datetime, timezone
+
+from gundi_client_v2 import GundiClient, GundiDataSenderClient
+
+
+def get_client_kwargs():
+    """Build GundiClient kwargs from environment."""
+    username = os.environ.get("GUNDI_USERNAME")
+    password = os.environ.get("GUNDI_PASSWORD")
+    if not username or not password:
+        raise ValueError(
+            "Set GUNDI_USERNAME and GUNDI_PASSWORD in the environment, or pass them in code."
+        )
+    kwargs = {"username": username, "password": password}
+    if os.environ.get("OAUTH_TOKEN_URL"):
+        kwargs["oauth_token_url"] = os.environ["OAUTH_TOKEN_URL"]
+    elif os.environ.get("OAUTH_ISSUER"):
+        kwargs["oauth_token_url"] = (
+            f"{os.environ['OAUTH_ISSUER'].rstrip('/')}/protocol/openid-connect/token"
+        )
+    if os.environ.get("OAUTH_CLIENT_ID"):
+        kwargs["oauth_client_id"] = os.environ["OAUTH_CLIENT_ID"]
+    if os.environ.get("OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = os.environ["OAUTH_AUDIENCE"]
+    if os.environ.get("GUNDI_API_BASE_URL"):
+        kwargs["base_url"] = os.environ["GUNDI_API_BASE_URL"]
+    return kwargs
+
+
+def get_sender_kwargs():
+    """Build GundiDataSenderClient kwargs from environment (optional base URL)."""
+    kwargs = {}
+    if os.environ.get("SENSORS_API_BASE_URL"):
+        kwargs["sensors_api_base_url"] = os.environ["SENSORS_API_BASE_URL"]
+    return kwargs
+
+
+async def main():
+    integration_name = os.environ.get("GUNDI_INTEGRATION_NAME")
+    if not integration_name:
+        raise ValueError(
+            "Set GUNDI_INTEGRATION_NAME to the name of the integration to use for sending."
+        )
+
+    client_kwargs = get_client_kwargs()
+    sender_kwargs = get_sender_kwargs()
+
+    async with GundiClient(**client_kwargs) as client:
+        # 1. Authenticate (implicit on first request) and query integrations
+        integration = None
+        names = []
+        async for i in client.get_integrations():
+            names.append(i.name)
+            if i.name == integration_name:
+                integration = i
+                break
+        if not integration:
+            raise ValueError(
+                f"No integration named {integration_name!r}. Available: {names}"
+            )
+
+        # 2. Get the integration's API key
+        api_key = await client.get_integration_api_key(integration.id)
+        if not api_key:
+            raise ValueError(
+                f"Integration {integration_name!r} has no API key."
+            )
+
+    # 3. Send observations using GundiDataSenderClient
+    sender = GundiDataSenderClient(
+        integration_api_key=api_key,
+        **sender_kwargs,
+    )
+    observations = [
+        {
+            "source": 2,
+            "source_name": "Python example script",
+            "type": "tracking-device",
+            "recorded_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            "location": {"lat": -12.398828, "lon": -74.263916},
+            "additional": {"example": True},
+        }
+    ]
+    response = await sender.post_observations(observations)
+    print("Sent observations. Response:", response)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -4,14 +4,18 @@ then use GundiDataSenderClient to send observations to Gundi.
 
 Set credentials via environment variables (recommended) or pass them in code.
 
-# Required (read by this script; one of OAUTH_ISSUER or OAUTH_TOKEN_URL must be set):
+# Required:
 #   GUNDI_USERNAME, GUNDI_PASSWORD,
 #   GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
-#   OAUTH_CLIENT_ID, OAUTH_AUDIENCE,
-#   OAUTH_ISSUER  (library derives the token URL as {issuer}/protocol/openid-connect/token)
-#     OR
-#   OAUTH_TOKEN_URL  (read by this script and passed as the oauth_token_url kwarg to GundiClient)
-# Optional: OAUTH_AUDIENCE, GUNDI_API_SSL_VERIFY
+#   OAUTH_CLIENT_ID,
+#   one of OAUTH_ISSUER (library discovers the token endpoint via OIDC discovery)
+#   or OAUTH_TOKEN_URL (used as-is when set).
+# Conditional:
+#   OAUTH_AUDIENCE  — required by some IdPs (e.g., Auth0 won't issue a usable
+#                     API access token without it); ignored by others (Keycloak
+#                     password grant). Set it if your IdP requires it.
+# Optional:
+#   GUNDI_API_SSL_VERIFY
 
 Run from the examples/ directory (so the .env file in that directory is loaded):
 

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -60,12 +60,9 @@ def get_client_kwargs():
     if oauth_token_url:
         kwargs["oauth_token_url"] = oauth_token_url
     elif oauth_issuer:
-        # Note: OAUTH_ISSUER must not have a trailing slash — the token URL is
-        # derived by appending /protocol/openid-connect/token and the value is
-        # not stripped.
-        kwargs["oauth_token_url"] = (
-            f"{oauth_issuer}/protocol/openid-connect/token"
-        )
+        # Pass the issuer to the client; it discovers the token endpoint via
+        # OIDC discovery ({issuer}/.well-known/openid-configuration) automatically.
+        kwargs["oauth_issuer"] = oauth_issuer
     kwargs["oauth_client_id"] = oauth_client_id
     kwargs["base_url"] = gundi_api_base_url
     if os.environ.get("OAUTH_AUDIENCE"):

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -3,9 +3,20 @@ Example: Authenticate with username/password, get an integration's API key by na
 then use GundiDataSenderClient to send observations to Gundi.
 
 Set credentials via environment variables (recommended) or pass them in code.
-Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME
-Optional: OAUTH_ISSUER (or OAUTH_TOKEN_URL), OAUTH_CLIENT_ID, OAUTH_AUDIENCE,
-          GUNDI_API_BASE_URL, SENSORS_API_BASE_URL
+
+Required: GUNDI_USERNAME, GUNDI_PASSWORD, GUNDI_INTEGRATION_NAME,
+          OAUTH_CLIENT_ID, GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
+          and at least one of OAUTH_TOKEN_URL or OAUTH_ISSUER.
+Optional: OAUTH_AUDIENCE, GUNDI_API_SSL_VERIFY
+
+Run from the examples/ directory (so the .env file in that directory is loaded):
+
+    cd examples
+    python send_observations.py
+
+Or from the repo root using GUNDI_CLIENT_ENVFILE:
+
+    GUNDI_CLIENT_ENVFILE=examples/.env python examples/send_observations.py
 """
 
 import asyncio
@@ -16,35 +27,56 @@ from gundi_client_v2 import GundiClient, GundiDataSenderClient
 
 
 def get_client_kwargs():
-    """Build GundiClient kwargs from environment."""
+    """Build GundiClient kwargs from environment, validating required settings."""
     username = os.environ.get("GUNDI_USERNAME")
     password = os.environ.get("GUNDI_PASSWORD")
     if not username or not password:
         raise ValueError(
             "Set GUNDI_USERNAME and GUNDI_PASSWORD in the environment, or pass them in code."
         )
-    kwargs = {"username": username, "password": password}
-    if os.environ.get("OAUTH_TOKEN_URL"):
-        kwargs["oauth_token_url"] = os.environ["OAUTH_TOKEN_URL"]
-    elif os.environ.get("OAUTH_ISSUER"):
-        kwargs["oauth_token_url"] = (
-            f"{os.environ['OAUTH_ISSUER'].rstrip('/')}/protocol/openid-connect/token"
+
+    oauth_client_id = os.environ.get("OAUTH_CLIENT_ID")
+    oauth_token_url = os.environ.get("OAUTH_TOKEN_URL")
+    oauth_issuer = os.environ.get("OAUTH_ISSUER")
+    gundi_api_base_url = os.environ.get("GUNDI_API_BASE_URL")
+
+    missing = []
+    if not oauth_client_id:
+        missing.append("OAUTH_CLIENT_ID")
+    if not oauth_token_url and not oauth_issuer:
+        missing.append("OAUTH_TOKEN_URL (or OAUTH_ISSUER)")
+    if not gundi_api_base_url:
+        missing.append("GUNDI_API_BASE_URL")
+    if missing:
+        raise ValueError(
+            f"Missing required environment variable(s): {', '.join(missing)}"
         )
-    if os.environ.get("OAUTH_CLIENT_ID"):
-        kwargs["oauth_client_id"] = os.environ["OAUTH_CLIENT_ID"]
+
+    kwargs = {"username": username, "password": password}
+    if oauth_token_url:
+        kwargs["oauth_token_url"] = oauth_token_url
+    elif oauth_issuer:
+        # Note: OAUTH_ISSUER must not have a trailing slash — the token URL is
+        # derived by appending /protocol/openid-connect/token and the value is
+        # not stripped.
+        kwargs["oauth_token_url"] = (
+            f"{oauth_issuer}/protocol/openid-connect/token"
+        )
+    kwargs["oauth_client_id"] = oauth_client_id
+    kwargs["base_url"] = gundi_api_base_url
     if os.environ.get("OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = os.environ["OAUTH_AUDIENCE"]
-    if os.environ.get("GUNDI_API_BASE_URL"):
-        kwargs["base_url"] = os.environ["GUNDI_API_BASE_URL"]
     return kwargs
 
 
 def get_sender_kwargs():
-    """Build GundiDataSenderClient kwargs from environment (optional base URL)."""
-    kwargs = {}
-    if os.environ.get("SENSORS_API_BASE_URL"):
-        kwargs["sensors_api_base_url"] = os.environ["SENSORS_API_BASE_URL"]
-    return kwargs
+    """Build GundiDataSenderClient kwargs from environment, validating required settings."""
+    sensors_api_base_url = os.environ.get("SENSORS_API_BASE_URL")
+    if not sensors_api_base_url:
+        raise ValueError(
+            "Missing required environment variable: SENSORS_API_BASE_URL"
+        )
+    return {"sensors_api_base_url": sensors_api_base_url}
 
 
 async def main():
@@ -66,7 +98,7 @@ async def main():
             if i.name == integration_name:
                 integration = i
                 break
-        if not integration:
+        if integration is None:
             raise ValueError(
                 f"No integration named {integration_name!r}. Available: {names}"
             )

--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.7.0"
+__version__ = "3.0.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/auth.py
+++ b/gundi_client_v2/auth.py
@@ -107,6 +107,38 @@ async def refresh_access_token(
     return OAuthToken.parse_obj(body), refresh_rotated
 
 
+async def get_access_token_client_credentials(
+    session,
+    oauth_token_url,
+    client_id,
+    client_secret,
+    audience=None,
+    scope="openid",
+):
+    """Standard OAuth2 client_credentials grant (RFC 6749 §4.4) for confidential clients.
+
+    Responses for client_credentials typically do NOT include a refresh_token
+    (RFC 6749 §4.4.3 says SHOULD NOT). We backfill empty values so the OAuthToken
+    schema (which requires both fields) still parses; the client orchestrator
+    treats the empty refresh_token + refresh_expires_in=0 as 'no refresh available'
+    and re-authenticates on each access-token expiry.
+    """
+    logger.debug(f"get_access_token (client_credentials) from {oauth_token_url} using client_id: {client_id}")
+    payload = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "client_credentials",
+        "scope": scope,
+    }
+    if audience:
+        payload["audience"] = audience
+    body = await _post_token(session, oauth_token_url, payload)
+    # Treat missing OR explicit-null refresh fields as 'no refresh available'.
+    body["refresh_token"] = body.get("refresh_token") or ""
+    body["refresh_expires_in"] = body.get("refresh_expires_in") or 0
+    return OAuthToken.parse_obj(body)
+
+
 _DISCOVERY_CACHE: dict[str, str] = {}
 
 

--- a/gundi_client_v2/auth.py
+++ b/gundi_client_v2/auth.py
@@ -138,7 +138,13 @@ async def discover_token_endpoint(session, issuer: str) -> str:
     call :func:`clear_discovery_cache` to invalidate.
 
     The cache key is ``issuer.rstrip('/')`` so values differing only by a trailing
-    slash share one cache entry.
+    slash share one cache entry. The same normalization is applied when comparing
+    the returned ``issuer`` claim to the expected value.
+
+    Per OIDC Discovery 1.0 §4.3 (Validation of Issuer Identifier), the ``issuer``
+    field in the discovery document MUST match the URL used to fetch it; otherwise
+    a misconfigured (or hostile) response could redirect credentials at a token
+    endpoint for a different IdP. A mismatch raises ``AuthenticationError``.
     """
     key = issuer.rstrip("/")
     if key in _DISCOVERY_CACHE:
@@ -152,11 +158,26 @@ async def discover_token_endpoint(session, issuer: str) -> str:
             f"OIDC discovery failed for {issuer}: {e}"
         ) from e
     try:
-        token_endpoint = response.json()["token_endpoint"]
-    except (ValueError, KeyError, TypeError) as e:
+        body = response.json()
+    except ValueError as e:
+        raise AuthenticationError(
+            f"OIDC discovery document at {discovery_url} is not valid JSON"
+        ) from e
+    if not isinstance(body, dict):
+        raise AuthenticationError(
+            f"OIDC discovery document at {discovery_url} is not a JSON object"
+        )
+    returned_issuer = body.get("issuer")
+    if not isinstance(returned_issuer, str) or returned_issuer.rstrip("/") != key:
+        raise AuthenticationError(
+            f"OIDC discovery document at {discovery_url} returned issuer "
+            f"{returned_issuer!r} which does not match the expected issuer {issuer!r}"
+        )
+    if "token_endpoint" not in body:
         raise AuthenticationError(
             f"OIDC discovery document at {discovery_url} is missing 'token_endpoint'"
-        ) from e
+        )
+    token_endpoint = body["token_endpoint"]
     if not isinstance(token_endpoint, str):
         raise AuthenticationError(
             f"OIDC discovery document at {discovery_url} has a non-string 'token_endpoint': {token_endpoint!r}"

--- a/gundi_client_v2/auth.py
+++ b/gundi_client_v2/auth.py
@@ -105,3 +105,45 @@ async def refresh_access_token(
     body.setdefault("refresh_token", fallback.refresh_token)
     body.setdefault("refresh_expires_in", fallback.refresh_expires_in)
     return OAuthToken.parse_obj(body), refresh_rotated
+
+
+_DISCOVERY_CACHE: dict[str, str] = {}
+
+
+def clear_discovery_cache() -> None:
+    """Clear the OIDC discovery cache. Useful for tests and for long-running
+    processes that need to pick up an IdP configuration change without a restart."""
+    _DISCOVERY_CACHE.clear()
+
+
+async def discover_token_endpoint(session, issuer: str) -> str:
+    """Fetch the OIDC discovery document at ``{issuer}/.well-known/openid-configuration``
+    and return its ``token_endpoint``. Cached per-issuer for the process lifetime;
+    call :func:`clear_discovery_cache` to invalidate.
+
+    The cache key is ``issuer.rstrip('/')`` so values differing only by a trailing
+    slash share one cache entry.
+    """
+    key = issuer.rstrip("/")
+    if key in _DISCOVERY_CACHE:
+        return _DISCOVERY_CACHE[key]
+    discovery_url = f"{key}/.well-known/openid-configuration"
+    try:
+        response = await session.get(discovery_url)
+        response.raise_for_status()
+    except httpx.HTTPError as e:
+        raise AuthenticationError(
+            f"OIDC discovery failed for {issuer}: {e}"
+        ) from e
+    try:
+        token_endpoint = response.json()["token_endpoint"]
+    except (ValueError, KeyError, TypeError) as e:
+        raise AuthenticationError(
+            f"OIDC discovery document at {discovery_url} is missing 'token_endpoint'"
+        ) from e
+    if not isinstance(token_endpoint, str):
+        raise AuthenticationError(
+            f"OIDC discovery document at {discovery_url} has a non-string 'token_endpoint': {token_endpoint!r}"
+        )
+    _DISCOVERY_CACHE[key] = token_endpoint
+    return token_endpoint

--- a/gundi_client_v2/auth.py
+++ b/gundi_client_v2/auth.py
@@ -7,9 +7,6 @@ from .errors import AuthenticationError
 
 logger = logging.getLogger(__name__)
 
-UMA_TICKET_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:uma-ticket"
-
-
 def _extract_oauth_error(response):
     """Build a detail string from an RFC 6749 §5.2 token-error response."""
     status = response.status_code
@@ -41,19 +38,6 @@ async def _post_token(session, oauth_token_url, payload) -> dict:
 
 async def _token_request(session, oauth_token_url, payload) -> OAuthToken:
     return OAuthToken.parse_obj(await _post_token(session, oauth_token_url, payload))
-
-
-async def get_access_token(session, oauth_token_url, client_id, client_secret, audience=None, scope="openid"):
-    logger.debug(f"get_access_token from {oauth_token_url} using client_id: {client_id}")
-    payload = {
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "grant_type": UMA_TICKET_GRANT_TYPE,
-        "scope": scope,
-    }
-    if audience:
-        payload["audience"] = audience
-    return await _token_request(session, oauth_token_url, payload)
 
 
 # NOTE: The Resource Owner Password Credentials (ROPC) grant is discouraged by OAuth 2.1

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -234,6 +234,8 @@ class GundiClient:
 
     async def _refresh_token(self):
         now = datetime.now(tz=timezone.utc)
+        token_url = await self._resolve_token_url()
+
         # 1. Prefer the refresh-token grant when we hold a live refresh token.
         if (
             self.cached_token
@@ -243,7 +245,7 @@ class GundiClient:
             try:
                 token, refresh_rotated = await auth.refresh_access_token(
                     session=self._session,
-                    oauth_token_url=self.oauth_token_url,
+                    oauth_token_url=token_url,
                     client_id=self.client_id,
                     refresh_token=self.cached_token.refresh_token,
                     fallback=self.cached_token,
@@ -263,7 +265,6 @@ class GundiClient:
         # reject it remotely instead of failing locally with a clear configuration error.
         if self.username and self.password and self.client_id:
             logger.debug("Authenticating via password grant.")
-            token_url = await self._resolve_token_url()
             token = await auth.get_access_token_password_grant(
                 session=self._session,
                 oauth_token_url=token_url,
@@ -274,10 +275,10 @@ class GundiClient:
                 scope=self.scope,
             )
         elif self.client_id and self.client_secret:
-            logger.debug("Authenticating via client-credentials (uma-ticket) grant.")
-            token = await auth.get_access_token(
+            logger.debug("Authenticating via client_credentials grant.")
+            token = await auth.get_access_token_client_credentials(
                 session=self._session,
-                oauth_token_url=self.oauth_token_url,
+                oauth_token_url=token_url,
                 client_id=self.client_id,
                 client_secret=self.client_secret,
                 audience=self.audience,

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -216,6 +216,46 @@ class GundiClient:
             )
         return response
 
+    async def _patch(self, url, data: dict = None, params=None, headers=None, **kwargs):
+        headers = headers or {}
+        auth_headers = await self.get_auth_header()
+        response = await self._session.patch(
+            url,
+            json=data,
+            params=params,
+            headers={**auth_headers, **headers},
+            **kwargs,
+        )
+        if response.status_code == 302 and "auth/realms" in response.headers.get("location", ""):
+            auth_headers = await self.get_auth_header(force_refresh_token=True)
+            response = await self._session.patch(
+                url,
+                json=data,
+                params=params,
+                headers={**auth_headers, **headers},
+                **kwargs,
+            )
+        return response
+
+    async def _delete(self, url, params=None, headers=None, **kwargs):
+        headers = headers or {}
+        auth_headers = await self.get_auth_header()
+        response = await self._session.delete(
+            url,
+            params=params,
+            headers={**auth_headers, **headers},
+            **kwargs,
+        )
+        if response.status_code == 302 and "auth/realms" in response.headers.get("location", ""):
+            auth_headers = await self.get_auth_header(force_refresh_token=True)
+            response = await self._session.delete(
+                url,
+                params=params,
+                headers={**auth_headers, **headers},
+                **kwargs,
+            )
+        return response
+
     async def _resolve_token_url(self) -> str:
         """Return the token endpoint URL. Explicit oauth_token_url wins; otherwise
         discover it from oauth_issuer via OIDC discovery. Discovery results are
@@ -357,12 +397,46 @@ class GundiClient:
         data = response.json()
         return Connection.parse_obj(data)
 
+    async def get_routes(self, params: dict = None) -> List[Route]:
+        url = f"{self.routes_endpoint}/"
+        response = await self._get(url, params=params)
+        self._raise_for_status(response)
+        return self._parse_list_response(response.json(), Route)
+
+    async def get_routes_for_connection(self, connection_id) -> List[Route]:
+        """List routes where the given connection appears as a data provider.
+
+        This is a convenience wrapper around ``get_routes(params={"provider": ...})``.
+        To combine the provider filter with other server-side filters (e.g.
+        ``owner``, ``destination``), call ``get_routes`` directly with a merged
+        params dict.
+        """
+        return await self.get_routes(params={"provider": str(connection_id)})
+
     async def get_route_details(self, route_id):
         url = f"{self.routes_endpoint}/{route_id}/"
         response = await self._get(url)
         self._raise_for_status(response)
         data = response.json()
         return Route.parse_obj(data)
+
+    async def create_route(self, data: dict) -> Route:
+        url = f"{self.routes_endpoint}/"
+        response = await self._post(url, data=data)
+        self._raise_for_status(response)
+        return Route.parse_obj(response.json())
+
+    async def update_route(self, route_id, data: dict) -> Route:
+        url = f"{self.routes_endpoint}/{route_id}/"
+        response = await self._patch(url, data=data)
+        self._raise_for_status(response)
+        return Route.parse_obj(response.json())
+
+    async def delete_route(self, route_id) -> None:
+        url = f"{self.routes_endpoint}/{route_id}/"
+        response = await self._delete(url)
+        self._raise_for_status(response)
+        # 204 No Content on success — no body to return.
 
     async def get_integrations(self, params: dict = None) -> AsyncGenerator[Integration, None]:
         url = f"{self.integrations_endpoint}/"

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -218,16 +218,14 @@ class GundiClient:
 
     async def _resolve_token_url(self) -> str:
         """Return the token endpoint URL. Explicit oauth_token_url wins; otherwise
-        discover it from oauth_issuer via OIDC discovery and memoize the result on
-        the instance so subsequent reads of self.oauth_token_url see it. Raises
-        AuthenticationError if neither is set."""
+        discover it from oauth_issuer via OIDC discovery. Discovery results are
+        cached process-wide in auth._DISCOVERY_CACHE, so repeated calls with the
+        same issuer are cheap (one dict lookup). Raises AuthenticationError if
+        neither is set."""
         if self.oauth_token_url:
             return self.oauth_token_url
         if self.oauth_issuer:
-            self.oauth_token_url = await auth.discover_token_endpoint(
-                self._session, self.oauth_issuer
-            )
-            return self.oauth_token_url
+            return await auth.discover_token_endpoint(self._session, self.oauth_issuer)
         raise errors.AuthenticationError(
             "No token URL configured. Set oauth_token_url or oauth_issuer."
         )

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -145,6 +145,7 @@ class GundiClient:
         self.username = kwargs.get("username", settings.GUNDI_USERNAME)
         self.password = kwargs.get("password", settings.GUNDI_PASSWORD)
         self.oauth_token_url = kwargs.get("oauth_token_url", settings.OAUTH_TOKEN_URL)
+        self.oauth_issuer = kwargs.get("oauth_issuer", settings.OAUTH_ISSUER)
         self.audience = kwargs.get("oauth_audience",
                                    kwargs.get("keycloak_audience", settings.OAUTH_AUDIENCE))
         self.scope = kwargs.get("oauth_scope", settings.OAUTH_SCOPE)
@@ -215,6 +216,22 @@ class GundiClient:
             )
         return response
 
+    async def _resolve_token_url(self) -> str:
+        """Return the token endpoint URL. Explicit oauth_token_url wins; otherwise
+        discover it from oauth_issuer via OIDC discovery and memoize the result on
+        the instance so subsequent reads of self.oauth_token_url see it. Raises
+        AuthenticationError if neither is set."""
+        if self.oauth_token_url:
+            return self.oauth_token_url
+        if self.oauth_issuer:
+            self.oauth_token_url = await auth.discover_token_endpoint(
+                self._session, self.oauth_issuer
+            )
+            return self.oauth_token_url
+        raise errors.AuthenticationError(
+            "No token URL configured. Set oauth_token_url or oauth_issuer."
+        )
+
     async def _refresh_token(self):
         now = datetime.now(tz=timezone.utc)
         # 1. Prefer the refresh-token grant when we hold a live refresh token.
@@ -246,9 +263,10 @@ class GundiClient:
         # reject it remotely instead of failing locally with a clear configuration error.
         if self.username and self.password and self.client_id:
             logger.debug("Authenticating via password grant.")
+            token_url = await self._resolve_token_url()
             token = await auth.get_access_token_password_grant(
                 session=self._session,
-                oauth_token_url=self.oauth_token_url,
+                oauth_token_url=token_url,
                 client_id=self.client_id,
                 username=self.username,
                 password=self.password,

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -292,16 +292,29 @@ class GundiClient:
         return token
 
     def _store_token(self, token, *, refresh_rotated=True):
-        # OAuthToken (gundi-core) always carries access + refresh fields on a successful parse.
+        # OAuthToken (gundi-core) always carries access + refresh fields on a successful parse,
+        # but for grants that don't issue refresh tokens (e.g. client_credentials) the auth
+        # helper backfills empty refresh_token and refresh_expires_in=0. Detect that here.
         # ``refresh_rotated`` is False only when this token came from a refresh-grant response
         # that omitted a new refresh_token (RFC 6749 §6) — in that case we preserve the
         # existing cached_token_refresh_expires_at because the cached refresh token is still
         # valid for its original lifetime.
         now = datetime.now(tz=timezone.utc)
         self.cached_token = token
-        self.cached_token_expires_at = now + timedelta(seconds=self._expiry_with_buffer(token.expires_in))
+        self.cached_token_expires_at = now + timedelta(
+            seconds=self._expiry_with_buffer(token.expires_in)
+        )
         if refresh_rotated:
-            self.cached_token_refresh_expires_at = now + timedelta(seconds=self._expiry_with_buffer(token.refresh_expires_in))
+            # `> 0` treats both zero (the backfilled refreshless case) and any negative
+            # `refresh_expires_in` (server bug / weird IdP) as 'no refresh available'.
+            if token.refresh_token and token.refresh_expires_in > 0:
+                self.cached_token_refresh_expires_at = now + timedelta(
+                    seconds=self._expiry_with_buffer(token.refresh_expires_in)
+                )
+            else:
+                # Refreshless grant — disable refresh tracking so the refresh-token
+                # branch in _refresh_token doesn't pick this up.
+                self.cached_token_refresh_expires_at = datetime.min.replace(tzinfo=timezone.utc)
 
     @staticmethod
     def _expiry_with_buffer(lifetime_seconds, buffer_seconds=15):

--- a/gundi_client_v2/settings.py
+++ b/gundi_client_v2/settings.py
@@ -11,9 +11,11 @@ else:
     # Default behavior
     env.read_env()
 
-# OAuth settings — OAUTH_* preferred; KEYCLOAK_* accepted for backward compatibility
+# OAuth settings — OAUTH_* preferred; KEYCLOAK_* accepted for backward compatibility.
+# The token URL is either set directly via OAUTH_TOKEN_URL or discovered at runtime
+# from OAUTH_ISSUER via the OIDC discovery document.
 OAUTH_ISSUER = env.str("OAUTH_ISSUER", env.str("KEYCLOAK_ISSUER", None))
-OAUTH_TOKEN_URL = f"{OAUTH_ISSUER}/protocol/openid-connect/token" if OAUTH_ISSUER else None
+OAUTH_TOKEN_URL = env.str("OAUTH_TOKEN_URL", None)
 OAUTH_CLIENT_ID = env.str("OAUTH_CLIENT_ID", env.str("KEYCLOAK_CLIENT_ID", None))
 OAUTH_CLIENT_SECRET = env.str("OAUTH_CLIENT_SECRET", env.str("KEYCLOAK_CLIENT_SECRET", None))
 OAUTH_AUDIENCE = env.str("OAUTH_AUDIENCE", env.str("KEYCLOAK_AUDIENCE", None))

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -27,7 +27,7 @@ async def test_authenticates_with_oauth_kwargs(auth_token_response):
         header = await client.get_auth_header()
         assert header["authorization"].startswith("Bearer ")
         params = _token_body(token_route)
-        assert params["grant_type"] == ["urn:ietf:params:oauth:grant-type:uma-ticket"]
+        assert params["grant_type"] == ["client_credentials"]
         assert params["client_id"] == ["confidential-client"]
         assert params["client_secret"] == ["shhh"]
 

--- a/tests/client/test_oidc_discovery.py
+++ b/tests/client/test_oidc_discovery.py
@@ -252,3 +252,62 @@ async def test_clear_discovery_cache_forces_rediscovery_for_existing_client(auth
         auth.clear_discovery_cache()                          # operator invalidates
         await client.get_access_token(force_refresh_token=True)  # next auth on the SAME client
         assert discovery_route.call_count == 2                # must have re-discovered
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_issuer_mismatch_raises():
+    """OIDC Discovery 1.0 §4.3: a discovery doc whose `issuer` claim does not
+    match the URL used to fetch it MUST be rejected — otherwise a misconfigured
+    or hostile response could redirect credentials to a token endpoint for a
+    different IdP."""
+    expected_issuer = "https://idp.example.com/realms/dev"
+    rogue_issuer = "https://attacker.example/realms/dev"
+    discovery_url = f"{expected_issuer}/.well-known/openid-configuration"
+    async with respx.mock as mock:
+        mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={
+                "issuer": rogue_issuer,
+                "token_endpoint": f"{rogue_issuer}/protocol/openid-connect/token",
+            },
+        )
+        async with httpx.AsyncClient() as session:
+            with pytest.raises(errors.AuthenticationError) as exc:
+                await auth.discover_token_endpoint(session, expected_issuer)
+        msg = str(exc.value)
+        assert rogue_issuer in msg
+        assert expected_issuer in msg
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_missing_issuer_raises():
+    """A discovery document with no `issuer` claim can't be validated; reject it."""
+    expected_issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{expected_issuer}/.well-known/openid-configuration"
+    async with respx.mock as mock:
+        mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"token_endpoint": f"{expected_issuer}/protocol/openid-connect/token"},
+        )
+        async with httpx.AsyncClient() as session:
+            with pytest.raises(errors.AuthenticationError) as exc:
+                await auth.discover_token_endpoint(session, expected_issuer)
+        assert expected_issuer in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_trailing_slash_in_returned_issuer_ok():
+    """A discovery doc whose `issuer` has a trailing slash should still match
+    a trailing-slash-less expected issuer (normalized via rstrip on both sides)."""
+    expected_issuer = "https://idp.example.com/realms/dev"
+    returned_issuer = "https://idp.example.com/realms/dev/"  # trailing slash
+    discovery_url = f"{expected_issuer}/.well-known/openid-configuration"
+    expected_token = f"{expected_issuer}/protocol/openid-connect/token"
+    async with respx.mock as mock:
+        mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": returned_issuer, "token_endpoint": expected_token},
+        )
+        async with httpx.AsyncClient() as session:
+            result = await auth.discover_token_endpoint(session, expected_issuer)
+        assert result == expected_token

--- a/tests/client/test_oidc_discovery.py
+++ b/tests/client/test_oidc_discovery.py
@@ -170,8 +170,6 @@ async def test_oauth_issuer_only_triggers_discovery(auth_token_response):
         await client.get_access_token()
         assert discovery_route.call_count == 1
         assert token_route.call_count == 1
-        # Memoization: after the first auth, the discovered URL is on self.
-        assert client.oauth_token_url == discovered_token_url
 
 
 @pytest.mark.asyncio
@@ -193,7 +191,7 @@ async def test_no_token_url_or_issuer_raises():
 async def test_refresh_branch_uses_discovered_url_after_initial_auth(auth_token_response):
     """Regression: in the issuer-only flow, the refresh branch fires after the
     access token expires; it must reuse the URL discovered during the initial auth
-    (memoized on self.oauth_token_url), not pass None."""
+    (served from auth._DISCOVERY_CACHE on the second call), not pass None."""
     issuer = "https://idp.example.com/realms/dev"
     discovery_url = f"{issuer}/.well-known/openid-configuration"
     discovered_token_url = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
@@ -221,3 +219,33 @@ async def test_refresh_branch_uses_discovered_url_after_initial_auth(auth_token_
         # Second call should have been the refresh grant — confirm via grant_type.
         second_body = parse_qs(token_route.calls[1].request.content.decode())
         assert second_body["grant_type"] == ["refresh_token"]
+
+
+@pytest.mark.asyncio
+async def test_clear_discovery_cache_forces_rediscovery_for_existing_client(auth_token_response):
+    """After clear_discovery_cache(), a client that previously discovered must rediscover
+    on its next auth attempt — i.e. the cache invalidation reaches the live client."""
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    discovered_token_url = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
+    client = GundiClient(
+        oauth_token_url=None,
+        oauth_issuer=issuer,
+        oauth_client_id="public-client",
+        username="alice",
+        password="s3cret",
+        base_url="https://api.fakeportal.com",
+    )
+    async with respx.mock as mock:
+        discovery_route = mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": discovered_token_url},
+        )
+        mock.post(discovered_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        await client.get_access_token()                       # initial auth via discovery
+        assert discovery_route.call_count == 1
+        auth.clear_discovery_cache()                          # operator invalidates
+        await client.get_access_token(force_refresh_token=True)  # next auth on the SAME client
+        assert discovery_route.call_count == 2                # must have re-discovered

--- a/tests/client/test_oidc_discovery.py
+++ b/tests/client/test_oidc_discovery.py
@@ -1,8 +1,10 @@
 import httpx
 import pytest
 import respx
+from urllib.parse import parse_qs
 
 from gundi_client_v2 import auth, errors
+from gundi_client_v2.client import GundiClient
 
 
 @pytest.mark.asyncio
@@ -112,3 +114,110 @@ async def test_discover_token_endpoint_non_string_value_raises():
             with pytest.raises(errors.AuthenticationError) as exc:
                 await auth.discover_token_endpoint(session, issuer)
         assert "non-string 'token_endpoint'" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_explicit_oauth_token_url_skips_discovery(auth_token_response):
+    explicit = "https://idp.example.com/explicit/token"
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    client = GundiClient(
+        oauth_token_url=explicit,
+        oauth_issuer=issuer,
+        oauth_client_id="public-client",
+        username="alice",
+        password="s3cret",
+        base_url="https://api.fakeportal.com",
+    )
+    async with respx.mock as mock:
+        discovery_route = mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": "https://wrong.example/token"},
+        )
+        token_route = mock.post(explicit).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        await client.get_access_token()
+        assert discovery_route.call_count == 0  # explicit URL wins
+        assert token_route.call_count == 1
+        body = parse_qs(token_route.calls.last.request.content.decode())
+        assert body["grant_type"] == ["password"]
+
+
+@pytest.mark.asyncio
+async def test_oauth_issuer_only_triggers_discovery(auth_token_response):
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    discovered_token_url = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
+    # Pass oauth_token_url=None explicitly so any OAUTH_TOKEN_URL env var
+    # cannot leak through settings.OAUTH_TOKEN_URL.
+    client = GundiClient(
+        oauth_token_url=None,
+        oauth_issuer=issuer,
+        oauth_client_id="public-client",
+        username="alice",
+        password="s3cret",
+        base_url="https://api.fakeportal.com",
+    )
+    async with respx.mock as mock:
+        discovery_route = mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": discovered_token_url},
+        )
+        token_route = mock.post(discovered_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        await client.get_access_token()
+        assert discovery_route.call_count == 1
+        assert token_route.call_count == 1
+        # Memoization: after the first auth, the discovered URL is on self.
+        assert client.oauth_token_url == discovered_token_url
+
+
+@pytest.mark.asyncio
+async def test_no_token_url_or_issuer_raises():
+    client = GundiClient(
+        oauth_client_id="public-client",
+        username="alice",
+        password="s3cret",
+        base_url="https://api.fakeportal.com",
+    )
+    client.oauth_token_url = None
+    client.oauth_issuer = None
+    with pytest.raises(errors.AuthenticationError) as exc:
+        await client.get_access_token()
+    assert str(exc.value) == "No token URL configured. Set oauth_token_url or oauth_issuer."
+
+
+@pytest.mark.asyncio
+async def test_refresh_branch_uses_discovered_url_after_initial_auth(auth_token_response):
+    """Regression: in the issuer-only flow, the refresh branch fires after the
+    access token expires; it must reuse the URL discovered during the initial auth
+    (memoized on self.oauth_token_url), not pass None."""
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    discovered_token_url = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
+    client = GundiClient(
+        oauth_token_url=None,
+        oauth_issuer=issuer,
+        oauth_client_id="public-client",
+        username="alice",
+        password="s3cret",
+        base_url="https://api.fakeportal.com",
+    )
+    async with respx.mock as mock:
+        discovery_route = mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": discovered_token_url},
+        )
+        token_route = mock.post(discovered_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        await client.get_access_token()                       # initial password grant via discovery
+        await client.get_access_token(force_refresh_token=True)  # refresh branch fires
+        # Discovery happened exactly once; both token requests went to the discovered URL.
+        assert discovery_route.call_count == 1
+        assert token_route.call_count == 2
+        # Second call should have been the refresh grant — confirm via grant_type.
+        second_body = parse_qs(token_route.calls[1].request.content.decode())
+        assert second_body["grant_type"] == ["refresh_token"]

--- a/tests/client/test_oidc_discovery.py
+++ b/tests/client/test_oidc_discovery.py
@@ -129,7 +129,10 @@ async def test_explicit_oauth_token_url_skips_discovery(auth_token_response):
         password="s3cret",
         base_url="https://api.fakeportal.com",
     )
-    async with respx.mock as mock:
+    # discovery_route is registered specifically to assert it is NOT called
+    # (explicit oauth_token_url wins); set assert_all_called=False explicitly
+    # so the intent survives future respx default changes.
+    async with respx.mock(assert_all_called=False) as mock:
         discovery_route = mock.get(discovery_url).respond(
             status_code=httpx.codes.OK,
             json={"issuer": issuer, "token_endpoint": "https://wrong.example/token"},

--- a/tests/client/test_oidc_discovery.py
+++ b/tests/client/test_oidc_discovery.py
@@ -1,0 +1,114 @@
+import httpx
+import pytest
+import respx
+
+from gundi_client_v2 import auth, errors
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_success():
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    expected = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
+    async with respx.mock as mock:
+        mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": expected},
+        )
+        async with httpx.AsyncClient() as session:
+            result = await auth.discover_token_endpoint(session, issuer)
+        assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_uses_cache_on_second_call():
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    expected = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
+    async with respx.mock as mock:
+        route = mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": expected},
+        )
+        async with httpx.AsyncClient() as session:
+            first = await auth.discover_token_endpoint(session, issuer)
+            second = await auth.discover_token_endpoint(session, issuer)
+        assert first == second == expected
+        assert route.call_count == 1  # second call must NOT hit the network
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_trailing_slash_shares_cache_entry():
+    issuer_plain = "https://idp.example.com/realms/dev"
+    issuer_slash = "https://idp.example.com/realms/dev/"
+    discovery_url = f"{issuer_plain}/.well-known/openid-configuration"
+    expected = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
+    async with respx.mock as mock:
+        route = mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer_plain, "token_endpoint": expected},
+        )
+        async with httpx.AsyncClient() as session:
+            a = await auth.discover_token_endpoint(session, issuer_plain)
+            b = await auth.discover_token_endpoint(session, issuer_slash)
+        assert a == b == expected
+        assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_5xx_raises_authentication_error():
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    async with respx.mock as mock:
+        mock.get(discovery_url).respond(status_code=503, text="Service Unavailable")
+        async with httpx.AsyncClient() as session:
+            with pytest.raises(errors.AuthenticationError) as exc:
+                await auth.discover_token_endpoint(session, issuer)
+        assert "OIDC discovery failed" in str(exc.value)
+        assert issuer in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_missing_token_endpoint_raises():
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    async with respx.mock as mock:
+        mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK, json={"issuer": issuer}  # no token_endpoint
+        )
+        async with httpx.AsyncClient() as session:
+            with pytest.raises(errors.AuthenticationError) as exc:
+                await auth.discover_token_endpoint(session, issuer)
+        assert "missing 'token_endpoint'" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_clear_discovery_cache_invalidates_cached_entry():
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    expected = "https://idp.example.com/realms/dev/protocol/openid-connect/token"
+    async with respx.mock as mock:
+        route = mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": expected},
+        )
+        async with httpx.AsyncClient() as session:
+            await auth.discover_token_endpoint(session, issuer)
+            auth.clear_discovery_cache()
+            await auth.discover_token_endpoint(session, issuer)
+        assert route.call_count == 2  # cache was cleared → second call re-fetches
+
+
+@pytest.mark.asyncio
+async def test_discover_token_endpoint_non_string_value_raises():
+    issuer = "https://idp.example.com/realms/dev"
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    async with respx.mock as mock:
+        mock.get(discovery_url).respond(
+            status_code=httpx.codes.OK,
+            json={"issuer": issuer, "token_endpoint": None},
+        )
+        async with httpx.AsyncClient() as session:
+            with pytest.raises(errors.AuthenticationError) as exc:
+                await auth.discover_token_endpoint(session, issuer)
+        assert "non-string 'token_endpoint'" in str(exc.value)

--- a/tests/client/test_password_grant.py
+++ b/tests/client/test_password_grant.py
@@ -1,10 +1,11 @@
 import httpx
 import pytest
 import respx
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
 from gundi_client_v2 import auth, errors
+from gundi_core.schemas import OAuthToken
 from gundi_client_v2.client import GundiClient
 
 TOKEN_URL = "https://fakeauth.com/realms/dev/protocol/openid-connect/token"
@@ -355,3 +356,41 @@ async def test_get_access_token_client_credentials_explicit_null_refresh_fields(
         assert token.access_token == "cc-token-value"
         assert token.refresh_token == ""
         assert token.refresh_expires_in == 0
+
+
+def test_store_token_refreshless_disables_refresh_tracking():
+    """When a token has no usable refresh fields (e.g., a client_credentials response
+    that's been backfilled with empty refresh_token/refresh_expires_in=0), _store_token
+    must set cached_token_refresh_expires_at to datetime.min so the refresh-grant branch
+    in _refresh_token is skipped on the next call."""
+    client = _confidential_client()
+    refreshless = OAuthToken.parse_obj({
+        "access_token": "fresh-access",
+        "expires_in": 1800,
+        "refresh_token": "",
+        "refresh_expires_in": 0,
+        "token_type": "Bearer",
+    })
+    client._store_token(refreshless)
+    assert client.cached_token.access_token == "fresh-access"
+    assert client.cached_token_refresh_expires_at == datetime.min.replace(tzinfo=timezone.utc)
+    # access-token expiry should still be set to a future moment via the buffer math
+    assert client.cached_token_expires_at > datetime.now(tz=timezone.utc)
+
+
+def test_store_token_refresh_not_rotated_preserves_existing_expiry():
+    """refresh_rotated=False (RFC 6749 §6 partial response — IdP omitted refresh_token)
+    must never touch cached_token_refresh_expires_at, even when the token's own refresh
+    fields are empty. Locks in the no-touch semantics from PR #38."""
+    client = _confidential_client()
+    sentinel = datetime.now(tz=timezone.utc) + timedelta(hours=12)
+    client.cached_token_refresh_expires_at = sentinel
+    partial = OAuthToken.parse_obj({
+        "access_token": "new-access",
+        "expires_in": 1800,
+        "refresh_token": "",
+        "refresh_expires_in": 0,
+        "token_type": "Bearer",
+    })
+    client._store_token(partial, refresh_rotated=False)
+    assert client.cached_token_refresh_expires_at is sentinel

--- a/tests/client/test_password_grant.py
+++ b/tests/client/test_password_grant.py
@@ -173,11 +173,11 @@ async def test_short_lived_token_not_immediately_expired(auth_token_response):
 
 @pytest.mark.asyncio
 async def test_confidential_refresh_sends_client_secret(auth_token_response):
-    # A confidential (uma-ticket) client MUST send its client_secret on the refresh grant.
+    # A confidential (client_credentials) client MUST send its client_secret on the refresh grant.
     client = _confidential_client()
     async with respx.mock as mock:
         route = mock.post(TOKEN_URL).respond(status_code=httpx.codes.OK, json=auth_token_response)
-        await client.get_access_token()                          # initial uma-ticket grant
+        await client.get_access_token()                          # initial client_credentials grant
         await client.get_access_token(force_refresh_token=True)  # refresh grant
         assert route.call_count == 2
         second = _body(route, 1)
@@ -394,3 +394,27 @@ def test_store_token_refresh_not_rotated_preserves_existing_expiry():
     })
     client._store_token(partial, refresh_rotated=False)
     assert client.cached_token_refresh_expires_at is sentinel
+
+
+@pytest.mark.asyncio
+async def test_confidential_refresh_after_client_credentials_falls_back_to_full_auth(auth_token_response):
+    """A client_credentials initial response that lacks refresh_token must not be retried
+    on the refresh-token path; the next force_refresh must re-authenticate via client_credentials."""
+    client_credentials_response = {
+        "access_token": "cc-access-token",
+        "expires_in": auth_token_response["expires_in"],
+        "token_type": "Bearer",
+    }
+    client = _confidential_client()
+    async with respx.mock as mock:
+        route = mock.post(TOKEN_URL).respond(
+            status_code=httpx.codes.OK, json=client_credentials_response
+        )
+        await client.get_access_token()                          # initial client_credentials
+        # Mechanism: _store_token recognizes the refreshless response and disables refresh tracking.
+        assert client.cached_token_refresh_expires_at == datetime.min.replace(tzinfo=timezone.utc)
+        await client.get_access_token(force_refresh_token=True)  # forced re-auth
+        assert route.call_count == 2
+        # Both calls must be client_credentials — refresh path was disabled by the empty refresh_token.
+        assert _body(route, 0)["grant_type"] == ["client_credentials"]
+        assert _body(route, 1)["grant_type"] == ["client_credentials"]

--- a/tests/client/test_password_grant.py
+++ b/tests/client/test_password_grant.py
@@ -4,7 +4,7 @@ import respx
 from datetime import datetime, timezone
 from urllib.parse import parse_qs
 
-from gundi_client_v2 import errors
+from gundi_client_v2 import auth, errors
 from gundi_client_v2.client import GundiClient
 
 TOKEN_URL = "https://fakeauth.com/realms/dev/protocol/openid-connect/token"
@@ -258,3 +258,100 @@ async def test_password_grant_requires_client_id():
     with pytest.raises(errors.AuthenticationError) as exc:
         await client.get_access_token()
     assert "client_id" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_client_credentials_payload(auth_token_response):
+    """RFC 6749 §4.4: client_credentials grant sends client_id+secret with grant_type=client_credentials."""
+    token_url = "https://idp.example.com/oauth/token"
+    async with respx.mock as mock:
+        route = mock.post(token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        async with httpx.AsyncClient() as session:
+            token = await auth.get_access_token_client_credentials(
+                session,
+                oauth_token_url=token_url,
+                client_id="cid",
+                client_secret="csecret",
+            )
+        params = parse_qs(route.calls.last.request.content.decode())
+        assert params["grant_type"] == ["client_credentials"]
+        assert params["client_id"] == ["cid"]
+        assert params["client_secret"] == ["csecret"]
+        assert params["scope"] == ["openid"]
+        assert "audience" not in params
+        assert token.access_token == auth_token_response["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_client_credentials_with_audience_and_scope(auth_token_response):
+    token_url = "https://idp.example.com/oauth/token"
+    async with respx.mock as mock:
+        route = mock.post(token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        async with httpx.AsyncClient() as session:
+            token = await auth.get_access_token_client_credentials(
+                session,
+                oauth_token_url=token_url,
+                client_id="cid",
+                client_secret="csecret",
+                audience="my-api",
+                scope="openid api",
+            )
+        params = parse_qs(route.calls.last.request.content.decode())
+        assert params["audience"] == ["my-api"]
+        assert params["scope"] == ["openid api"]
+        assert token.access_token == auth_token_response["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_client_credentials_refreshless_response_parses():
+    """RFC 6749 §4.4.3: client_credentials response SHOULD NOT include refresh_token.
+    The function backfills empty refresh fields so OAuthToken (which requires them) still parses."""
+    refreshless = {
+        "access_token": "cc-token-value",
+        "expires_in": 1800,
+        "token_type": "Bearer",
+        # NO refresh_token or refresh_expires_in
+    }
+    token_url = "https://idp.example.com/oauth/token"
+    async with respx.mock as mock:
+        mock.post(token_url).respond(status_code=httpx.codes.OK, json=refreshless)
+        async with httpx.AsyncClient() as session:
+            token = await auth.get_access_token_client_credentials(
+                session,
+                oauth_token_url=token_url,
+                client_id="cid",
+                client_secret="csecret",
+            )
+        assert token.access_token == "cc-token-value"
+        assert token.refresh_token == ""
+        assert token.refresh_expires_in == 0
+
+
+@pytest.mark.asyncio
+async def test_get_access_token_client_credentials_explicit_null_refresh_fields():
+    """Some IdPs serialize 'no refresh token' as explicit null. The function must
+    still produce a valid OAuthToken, treating null like missing."""
+    null_refresh_response = {
+        "access_token": "cc-token-value",
+        "expires_in": 1800,
+        "token_type": "Bearer",
+        "refresh_token": None,
+        "refresh_expires_in": None,
+    }
+    token_url = "https://idp.example.com/oauth/token"
+    async with respx.mock as mock:
+        mock.post(token_url).respond(status_code=httpx.codes.OK, json=null_refresh_response)
+        async with httpx.AsyncClient() as session:
+            token = await auth.get_access_token_client_credentials(
+                session,
+                oauth_token_url=token_url,
+                client_id="cid",
+                client_secret="csecret",
+            )
+        assert token.access_token == "cc-token-value"
+        assert token.refresh_token == ""
+        assert token.refresh_expires_in == 0

--- a/tests/client/test_routes.py
+++ b/tests/client/test_routes.py
@@ -1,7 +1,11 @@
+import json
+
 import httpx
 import pytest
 import respx
 from gundi_core.schemas.v2 import Connection, Route, Integration
+
+from gundi_client_v2 import errors
 
 
 # ToDo: complete tests
@@ -28,3 +32,135 @@ async def test_get_route_details(
         )
         assert isinstance(route, Route)
         assert route == Route.parse_obj(route_details)
+
+
+@pytest.mark.asyncio
+async def test_get_routes_parses_results_envelope(auth_token_response, route_details, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.OK, json={"results": [route_details], "next": None}
+        )
+        routes = await gundi_client_v2.get_routes()
+        assert len(routes) == 1
+        assert isinstance(routes[0], Route)
+
+
+@pytest.mark.asyncio
+async def test_get_routes_parses_bare_list(auth_token_response, route_details, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.OK, json=[route_details]
+        )
+        routes = await gundi_client_v2.get_routes()
+        assert len(routes) == 1
+        assert isinstance(routes[0], Route)
+
+
+@pytest.mark.asyncio
+async def test_get_routes_for_connection_filters_by_provider(auth_token_response, route_details, gundi_client_v2):
+    connection_id = "ddd0946d-15b0-4308-b93d-e0470b6d33b6"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        route = mock.get(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.OK, json={"results": [route_details], "next": None}
+        )
+        await gundi_client_v2.get_routes_for_connection(connection_id)
+        # The request URL must include ?provider=<connection_id>
+        assert route.call_count == 1
+        request_url = str(route.calls.last.request.url)
+        assert f"provider={connection_id}" in request_url
+
+
+@pytest.mark.asyncio
+async def test_create_route_posts_with_data(auth_token_response, route_details, gundi_client_v2):
+    payload = {
+        "name": "TrapTagger → ER (events)",
+        "owner": "e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        "data_providers": ["ddd0946d-15b0-4308-b93d-e0470b6d33b6"],
+        "destinations": ["338225f3-91f9-4fe1-b013-353a229ce504"],
+    }
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        post_route = mock.post(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.CREATED, json=route_details
+        )
+        result = await gundi_client_v2.create_route(data=payload)
+        assert isinstance(result, Route)
+        assert post_route.call_count == 1
+        sent = json.loads(post_route.calls.last.request.content.decode())
+        assert sent == payload
+
+
+@pytest.mark.asyncio
+async def test_create_route_raises_gundi_api_error_on_400(auth_token_response, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.post(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=400, json={"detail": "bad route"}
+        )
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.create_route(data={"name": "broken"})
+        assert exc.value.status_code == 400
+        assert "bad route" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_update_route_patches_with_partial_data(auth_token_response, route_details, gundi_client_v2):
+    route_id = route_details["id"]
+    patch_payload = {"name": "Renamed"}
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        patch_route = mock.patch(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=httpx.codes.OK, json=route_details
+        )
+        result = await gundi_client_v2.update_route(route_id, data=patch_payload)
+        assert isinstance(result, Route)
+        assert patch_route.call_count == 1
+        # Confirm verb is PATCH and body matches the partial dict
+        assert patch_route.calls.last.request.method == "PATCH"
+        sent = json.loads(patch_route.calls.last.request.content.decode())
+        assert sent == patch_payload
+
+
+@pytest.mark.asyncio
+async def test_update_route_raises_gundi_api_error_on_400(auth_token_response, gundi_client_v2):
+    route_id = "bogus-id"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.patch(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=400, json={"detail": "bad patch"}
+        )
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.update_route(route_id, data={"name": ""})
+        assert exc.value.status_code == 400
+        assert "bad patch" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_delete_route_issues_delete_and_returns_none(auth_token_response, route_details, gundi_client_v2):
+    route_id = route_details["id"]
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        delete_route = mock.delete(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=204
+        )
+        result = await gundi_client_v2.delete_route(route_id)
+        assert result is None
+        assert delete_route.call_count == 1
+        assert delete_route.calls.last.request.method == "DELETE"
+
+
+@pytest.mark.asyncio
+async def test_delete_route_raises_on_404(auth_token_response, gundi_client_v2):
+    route_id = "nonexistent-uuid"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.delete(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=404, json={"detail": "Not found"}
+        )
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.delete_route(route_id)
+        assert exc.value.status_code == 404
+        assert "Not found" in exc.value.detail

--- a/tests/client/test_settings.py
+++ b/tests/client/test_settings.py
@@ -1,0 +1,41 @@
+import importlib
+
+import pytest
+
+from gundi_client_v2 import settings as settings_module
+
+
+@pytest.fixture(autouse=True)
+def _restore_settings_after_test():
+    """Reload settings after each test so the module state reflects the env
+    that pytest's monkeypatch fixture has restored, not the test's patched env."""
+    yield
+    importlib.reload(settings_module)
+
+
+def _isolate_envfile(monkeypatch, tmp_path):
+    """Point GUNDI_CLIENT_ENVFILE at an empty file so environs.read_env() during
+    importlib.reload doesn't re-merge a developer's local .env."""
+    empty = tmp_path / "empty.env"
+    empty.write_text("")
+    monkeypatch.setenv("GUNDI_CLIENT_ENVFILE", str(empty))
+
+
+def test_oauth_token_url_read_directly_from_env(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    monkeypatch.setenv("OAUTH_TOKEN_URL", "https://idp.example.com/oauth/token")
+    monkeypatch.delenv("OAUTH_ISSUER", raising=False)
+    monkeypatch.delenv("KEYCLOAK_ISSUER", raising=False)
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_TOKEN_URL == "https://idp.example.com/oauth/token"
+    assert reloaded.OAUTH_ISSUER is None
+
+
+def test_oauth_token_url_no_longer_derived_from_issuer(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    monkeypatch.setenv("OAUTH_ISSUER", "https://idp.example.com/realms/x")
+    monkeypatch.delenv("OAUTH_TOKEN_URL", raising=False)
+    monkeypatch.delenv("KEYCLOAK_ISSUER", raising=False)
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_ISSUER == "https://idp.example.com/realms/x"
+    assert reloaded.OAUTH_TOKEN_URL is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,15 @@ import pytest
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient
 
 
+@pytest.fixture(autouse=True)
+def _clear_oidc_discovery_cache():
+    """Keep the per-issuer OIDC discovery cache test-isolated."""
+    from gundi_client_v2 import auth as _auth
+    _auth.clear_discovery_cache()
+    yield
+    _auth.clear_discovery_cache()
+
+
 @pytest.fixture
 def sender_settings():
     return {


### PR DESCRIPTION
## Summary
Replaces the Keycloak-specific token-URL derivation with OIDC discovery and replaces the uma-ticket grant with standard `grant_type=client_credentials`, so the library works against any OIDC-compliant IdP (Keycloak today, Auth0 next).

- New `auth.discover_token_endpoint(session, issuer)` fetches `{issuer}/.well-known/openid-configuration` and returns its `token_endpoint`. Process-lifetime cache keyed by `issuer.rstrip("/")`; `auth.clear_discovery_cache()` is the public escape hatch.
- New `oauth_issuer` kwarg on `GundiClient`; settings-layer `OAUTH_TOKEN_URL` is now a direct env var (not a derived value).
- New `auth.get_access_token_client_credentials` replaces the uma-ticket grant. Handles refreshless responses (RFC 6749 §4.4.3) by backfilling empty refresh fields and letting `_store_token` disable refresh tracking.
- `_store_token` recognizes refreshless tokens; `_refresh_token` resolves the token URL once at the top via `_resolve_token_url` (which memoizes onto `self.oauth_token_url` so issuer-only flows work across the refresh-grant branch too).
- Backward compatibility preserved: existing `keycloak_*` kwargs, `KEYCLOAK_*` env fallbacks, and the module-level `KEYCLOAK_*` aliases all still work. Keycloak deployments using `OAUTH_ISSUER` keep working through discovery (Keycloak supports it natively).

**Version bump to 3.0.0** — the uma-ticket → client_credentials swap is a runtime-behavior break for any consumer relying on the old flow, and the `httpx>=0.28` constraint forces downstream `fastapi`/`starlette` upgrades.

## Test Plan
- [x] `pytest` — full suite 60 passed
- [x] OIDC discovery: success, cached, trailing slash shares cache, 5xx → AuthenticationError, missing `token_endpoint` → AuthenticationError, non-string `token_endpoint` → AuthenticationError, `clear_discovery_cache()` invalidates
- [x] Token URL resolution: explicit `oauth_token_url` skips discovery; `oauth_issuer` only triggers discovery and memoizes onto `self.oauth_token_url`; neither set → AuthenticationError; refresh-branch uses the discovered URL after initial auth
- [x] `client_credentials`: payload shape; conditional audience; refreshless response parses with empty backfill; explicit-null refresh fields parse cleanly
- [x] `_store_token` refreshless handling: `refresh_rotated=True`+refreshless → cached_token_refresh_expires_at = datetime.min; `refresh_rotated=False` preserves existing expiry
- [x] End-to-end: confidential client after a refreshless client_credentials response re-authenticates via client_credentials (no refresh-grant attempt)

## Downstream impact

Consumers will need to bump several transitive dependencies in lockstep — `httpx>=0.28` (existing on this branch) forces `starlette>=0.37` which forces `fastapi>=0.110.3`. The known-good compatible quadruple has been verified against the `gundi-integration-earthranger` test suite.

See [`MIGRATION.md`](https://github.com/PADAS/gundi-client/blob/cd/v2-oidc-discovery/MIGRATION.md) for the full 2.x → 3.0 upgrade guide including the auth-flow change, settings/env-var changes, IdP-specific audience notes, and troubleshooting.

## Notes
- Stacks on `cd/v2-docs` (PR #39) for development. Once #39 merges to v2, GitHub auto-retargets this PR's base.
- Spec: `docs/superpowers/specs/2026-05-29-gundi-client-v2-oidc-discovery-design.md` (on the planning-artifacts branch).
- Plan: `docs/superpowers/plans/2026-05-29-gundi-client-v2-oidc-discovery.md` (on the planning-artifacts branch).
