### PR TITLE
feat: routes CRUD + get_routes_for_connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,33 @@ async def main():
             integration_id="some-uuid"
         )
 
+        # List routes (optionally pass params= for server-side filtering)
+        routes = await client.get_routes()
+
+        # List routes where a connection is the data provider
+        routes = await client.get_routes_for_connection(
+            connection_id="some-provider-uuid"
+        )
+
         # Get route details
         route = await client.get_route_details(route_id="some-uuid")
+
+        # Create a route
+        new_route = await client.create_route(data={
+            "name": "TrapTagger → ER (events)",
+            "owner": "your-org-uuid",
+            "data_providers": ["provider-integration-uuid"],
+            "destinations": ["destination-integration-uuid"],
+        })
+
+        # Update a route (partial update via PATCH)
+        updated_route = await client.update_route(
+            route_id="some-uuid",
+            data={"name": "Renamed Route"},
+        )
+
+        # Delete a route
+        await client.delete_route(route_id="some-uuid")
 
         # Query traces
         traces = await client.get_traces(params={"object_id": "some-uuid"})

--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -216,6 +216,46 @@ class GundiClient:
             )
         return response
 
+    async def _patch(self, url, data: dict = None, params=None, headers=None, **kwargs):
+        headers = headers or {}
+        auth_headers = await self.get_auth_header()
+        response = await self._session.patch(
+            url,
+            json=data,
+            params=params,
+            headers={**auth_headers, **headers},
+            **kwargs,
+        )
+        if response.status_code == 302 and "auth/realms" in response.headers.get("location", ""):
+            auth_headers = await self.get_auth_header(force_refresh_token=True)
+            response = await self._session.patch(
+                url,
+                json=data,
+                params=params,
+                headers={**auth_headers, **headers},
+                **kwargs,
+            )
+        return response
+
+    async def _delete(self, url, params=None, headers=None, **kwargs):
+        headers = headers or {}
+        auth_headers = await self.get_auth_header()
+        response = await self._session.delete(
+            url,
+            params=params,
+            headers={**auth_headers, **headers},
+            **kwargs,
+        )
+        if response.status_code == 302 and "auth/realms" in response.headers.get("location", ""):
+            auth_headers = await self.get_auth_header(force_refresh_token=True)
+            response = await self._session.delete(
+                url,
+                params=params,
+                headers={**auth_headers, **headers},
+                **kwargs,
+            )
+        return response
+
     async def _resolve_token_url(self) -> str:
         """Return the token endpoint URL. Explicit oauth_token_url wins; otherwise
         discover it from oauth_issuer via OIDC discovery. Discovery results are
@@ -357,12 +397,46 @@ class GundiClient:
         data = response.json()
         return Connection.parse_obj(data)
 
+    async def get_routes(self, params: dict = None) -> List[Route]:
+        url = f"{self.routes_endpoint}/"
+        response = await self._get(url, params=params)
+        self._raise_for_status(response)
+        return self._parse_list_response(response.json(), Route)
+
+    async def get_routes_for_connection(self, connection_id) -> List[Route]:
+        """List routes where the given connection appears as a data provider.
+
+        This is a convenience wrapper around ``get_routes(params={"provider": ...})``.
+        To combine the provider filter with other server-side filters (e.g.
+        ``owner``, ``destination``), call ``get_routes`` directly with a merged
+        params dict.
+        """
+        return await self.get_routes(params={"provider": str(connection_id)})
+
     async def get_route_details(self, route_id):
         url = f"{self.routes_endpoint}/{route_id}/"
         response = await self._get(url)
         self._raise_for_status(response)
         data = response.json()
         return Route.parse_obj(data)
+
+    async def create_route(self, data: dict) -> Route:
+        url = f"{self.routes_endpoint}/"
+        response = await self._post(url, data=data)
+        self._raise_for_status(response)
+        return Route.parse_obj(response.json())
+
+    async def update_route(self, route_id, data: dict) -> Route:
+        url = f"{self.routes_endpoint}/{route_id}/"
+        response = await self._patch(url, data=data)
+        self._raise_for_status(response)
+        return Route.parse_obj(response.json())
+
+    async def delete_route(self, route_id) -> None:
+        url = f"{self.routes_endpoint}/{route_id}/"
+        response = await self._delete(url)
+        self._raise_for_status(response)
+        # 204 No Content on success — no body to return.
 
     async def get_integrations(self, params: dict = None) -> AsyncGenerator[Integration, None]:
         url = f"{self.integrations_endpoint}/"

--- a/tests/client/test_routes.py
+++ b/tests/client/test_routes.py
@@ -1,7 +1,11 @@
+import json
+
 import httpx
 import pytest
 import respx
 from gundi_core.schemas.v2 import Connection, Route, Integration
+
+from gundi_client_v2 import errors
 
 
 # ToDo: complete tests
@@ -28,3 +32,135 @@ async def test_get_route_details(
         )
         assert isinstance(route, Route)
         assert route == Route.parse_obj(route_details)
+
+
+@pytest.mark.asyncio
+async def test_get_routes_parses_results_envelope(auth_token_response, route_details, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.OK, json={"results": [route_details], "next": None}
+        )
+        routes = await gundi_client_v2.get_routes()
+        assert len(routes) == 1
+        assert isinstance(routes[0], Route)
+
+
+@pytest.mark.asyncio
+async def test_get_routes_parses_bare_list(auth_token_response, route_details, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.get(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.OK, json=[route_details]
+        )
+        routes = await gundi_client_v2.get_routes()
+        assert len(routes) == 1
+        assert isinstance(routes[0], Route)
+
+
+@pytest.mark.asyncio
+async def test_get_routes_for_connection_filters_by_provider(auth_token_response, route_details, gundi_client_v2):
+    connection_id = "ddd0946d-15b0-4308-b93d-e0470b6d33b6"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        route = mock.get(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.OK, json={"results": [route_details], "next": None}
+        )
+        await gundi_client_v2.get_routes_for_connection(connection_id)
+        # The request URL must include ?provider=<connection_id>
+        assert route.call_count == 1
+        request_url = str(route.calls.last.request.url)
+        assert f"provider={connection_id}" in request_url
+
+
+@pytest.mark.asyncio
+async def test_create_route_posts_with_data(auth_token_response, route_details, gundi_client_v2):
+    payload = {
+        "name": "TrapTagger → ER (events)",
+        "owner": "e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        "data_providers": ["ddd0946d-15b0-4308-b93d-e0470b6d33b6"],
+        "destinations": ["338225f3-91f9-4fe1-b013-353a229ce504"],
+    }
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        post_route = mock.post(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=httpx.codes.CREATED, json=route_details
+        )
+        result = await gundi_client_v2.create_route(data=payload)
+        assert isinstance(result, Route)
+        assert post_route.call_count == 1
+        sent = json.loads(post_route.calls.last.request.content.decode())
+        assert sent == payload
+
+
+@pytest.mark.asyncio
+async def test_create_route_raises_gundi_api_error_on_400(auth_token_response, gundi_client_v2):
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.post(f"{gundi_client_v2.routes_endpoint}/").respond(
+            status_code=400, json={"detail": "bad route"}
+        )
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.create_route(data={"name": "broken"})
+        assert exc.value.status_code == 400
+        assert "bad route" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_update_route_patches_with_partial_data(auth_token_response, route_details, gundi_client_v2):
+    route_id = route_details["id"]
+    patch_payload = {"name": "Renamed"}
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        patch_route = mock.patch(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=httpx.codes.OK, json=route_details
+        )
+        result = await gundi_client_v2.update_route(route_id, data=patch_payload)
+        assert isinstance(result, Route)
+        assert patch_route.call_count == 1
+        # Confirm verb is PATCH and body matches the partial dict
+        assert patch_route.calls.last.request.method == "PATCH"
+        sent = json.loads(patch_route.calls.last.request.content.decode())
+        assert sent == patch_payload
+
+
+@pytest.mark.asyncio
+async def test_update_route_raises_gundi_api_error_on_400(auth_token_response, gundi_client_v2):
+    route_id = "bogus-id"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.patch(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=400, json={"detail": "bad patch"}
+        )
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.update_route(route_id, data={"name": ""})
+        assert exc.value.status_code == 400
+        assert "bad patch" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_delete_route_issues_delete_and_returns_none(auth_token_response, route_details, gundi_client_v2):
+    route_id = route_details["id"]
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        delete_route = mock.delete(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=204
+        )
+        result = await gundi_client_v2.delete_route(route_id)
+        assert result is None
+        assert delete_route.call_count == 1
+        assert delete_route.calls.last.request.method == "DELETE"
+
+
+@pytest.mark.asyncio
+async def test_delete_route_raises_on_404(auth_token_response, gundi_client_v2):
+    route_id = "nonexistent-uuid"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(status_code=httpx.codes.OK, json=auth_token_response)
+        mock.delete(f"{gundi_client_v2.routes_endpoint}/{route_id}/").respond(
+            status_code=404, json={"detail": "Not found"}
+        )
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.delete_route(route_id)
+        assert exc.value.status_code == 404
+        assert "Not found" in exc.value.detail


### PR DESCRIPTION
## Summary

Adds the missing CRUD verbs on `GundiClient` for `/v2/routes/`, plus a convenience helper for listing the routes a given Connection participates in.

- `get_routes(params=None)` — list (`GET /v2/routes/`); reuses `_parse_list_response` so both bare-list and `{results, next}` envelopes parse.
- `get_routes_for_connection(connection_id)` — one-line wrapper around `get_routes(params={"provider": str(connection_id)})`. The filter param is `provider` (the alias declared on cdip's `RouteFilter`), not `data_providers`.
- `create_route(data: dict)` — POST.
- `update_route(route_id, data: dict)` — PATCH (partial update). PUT is intentionally not surfaced.
- `delete_route(route_id)` — DELETE; returns `None` on `204 No Content`, raises `GundiAPIError` on 4xx/5xx.

Adds two private HTTP helpers (`_patch`, `_delete`) modeled on `_post`, including the 302 login-redirect retry.

Version bump 2.6.0 → 2.7.0.

## Test Plan

- [x] `pytest` — 73 passed (1 pre-existing `test_get_route_details` + 9 new tests for the additions)
- [x] Each new test asserts real behavior — verb (PATCH/DELETE), URL (incl. `?provider=<uuid>`), body shape (`json.loads(request.content)`), and error mapping for create/update/delete 4xx → `GundiAPIError`
- [x] README updated with usage snippets for all new methods

## Notes

- Stacks on `cd/v2-oidc-discovery` (PR #41). Once #41 merges to `v2`, this PR's base auto-retargets.
- Spec: `docs/superpowers/specs/2026-05-30-gundi-client-v2-routes-crud-design.md` (on the planning-artifacts branch).
- The `data: dict` input shape for write methods matches the existing `register_integration_type` pattern — forward-compatible if the server adds fields, no client churn needed.
- Known follow-ups (deliberately not in this PR): extract a `_request(method, ...)` helper to deduplicate the 302-retry across `_get`/`_post`/`_patch`/`_delete`; add typed input models (TypedDict/pydantic) for the write `data` dicts; symmetric write methods for connections/integrations.