### PR TITLE
EXPERIMENT: loosen httpx pin to >=0.24,<1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 dependencies = [
     "environs>=9.5,<12",
     "pydantic>=1.10,<2",
-    "httpx>=0.28",
+    "httpx>=0.24,<1.0",
     "gundi-core>=1.5.8,<3",
 ]
 


### PR DESCRIPTION
## Purpose

**Exploratory / data-gathering PR, not intended to merge as-is.** Provides evidence for the deliberation about how much migration burden to push onto consumers in the next release.

The current `cd/v2-oidc-discovery` branch carries `httpx>=0.28` (a constraint introduced opportunistically in 2.4.1, Sept 2025). When a consumer bumps to the new gundi-client-v2, this forces them to bump httpx → which breaks `starlette.TestClient` (which still calls `httpx.Client(app=...)`) → which forces a starlette bump → which forces a fastapi bump → which cascades through their middleware. Real work for 30+ consumer repos.

This PR loosens the pin to `httpx>=0.24,<1.0` to see if that breaks anything in the library itself, and what it gives consumers.

## Findings

### Library test suite passes under both httpx versions

| Matrix | httpx | respx | Result |
|---|---|---|---|
| Old line | 0.24.1 | 0.20.2 | **73 passed** in 1.37s |
| Current | 0.28.1 | 0.23.1 | **73 passed** in 1.27s |

No regressions. The library uses only `httpx.codes.X`, `httpx.HTTPError`, `httpx.HTTPStatusError`, `session.post/get`, `response.raise_for_status()`, `response.json()` — all stable across the 0.24–0.28 range.

### Consumer (`gundi-integration-earthranger`) under loosened constraint

| Scenario | httpx resolved | Starlette TestClient | Consumer tests |
|---|---|---|---|
| Strict `httpx>=0.28` (status quo on `cd/v2-oidc-discovery`) | 0.28.1 | **BROKEN** (`TypeError: Client.__init__() got an unexpected keyword argument 'app'`) | n/a — collection errors |
| Loosened `httpx>=0.24,<1.0`, no consumer cap | 0.28.1 | Still broken — uv picks latest | n/a |
| Loosened + consumer pins `httpx<0.28` in requirements.in | 0.27.2 | Works (deprecation warning only) | **73 passed** |

## What this means for the publishing decision

The loose pin only helps consumers who **also** add `httpx<0.28` to their own requirements.in. So:

- **Strict `httpx>=0.28`** (status quo): forces every consumer to bump fastapi+starlette+middleware as part of adopting the new client. Pain happens once, all at once.
- **Loose `httpx>=0.24,<1.0`**: a consumer can ship a one-line `httpx<0.28` cap in their requirements.in and defer the fastapi/starlette migration to a separate change. Same end-state eventually, but the migrations decouple.

Either approach works. The trade-off is the same as for any compatibility loosening: more flexibility for consumers at the cost of a wider compat surface for us.

## What this PR does NOT do

- Add a CI matrix for httpx versions — there's no CI workflow in this repo today. Would be worth adding regardless of how this decision lands.
- Update respx in `[dependency-groups] dev` (dev-only; doesn't propagate to consumers).
- Update any docs or migration notes.

## How to verify

```bash
# Under httpx 0.24:
uv venv --python 3.10 .venv-h024
source .venv-h024/bin/activate
uv pip install -e . "httpx>=0.24,<0.25" "respx>=0.20,<0.21" pytest pytest-asyncio
pytest

# Under httpx 0.28:
uv venv --python 3.10 .venv-h028
source .venv-h028/bin/activate
uv pip install -e . "httpx>=0.28,<0.29" "respx>=0.22" pytest pytest-asyncio
pytest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)