### PR TITLE
Feat/add apply transformations

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.0"
+__version__ = "3.1.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/transformations.py
+++ b/gundi_client_v2/transformations.py
@@ -1,0 +1,135 @@
+"""Apply RouteConfiguration field_mappings to a generic Gundi payload.
+
+Used by action runners that consume `GundiDelivery` envelopes from cdip-routing.
+The function mirrors today's `FieldMappingRule` semantics in cdip-routing but
+writes to top-level fields on the generic Gundi Pydantic model instead of to a
+destination-shaped dict.
+
+Rules whose `destination_field` does not exist on the payload (e.g., the 564
+EarthRanger `provider_key` overrides) are logged and skipped — those values are
+delivery metadata, not data, and are handled elsewhere.
+"""
+
+import logging
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from gundi_core.schemas.v2 import RouteConfiguration
+
+logger = logging.getLogger(__name__)
+
+
+def apply_transformations(
+    payload: BaseModel,
+    route_configuration: Optional[RouteConfiguration],
+    *,
+    provider_id: str,
+    destination_id: str,
+) -> BaseModel:
+    """Apply transformations from route_configuration.field_mappings to payload.
+
+    Mutates and returns the same payload instance. Rules are looked up by the
+    triple (provider_id, stream_type, destination_id), where stream_type is read
+    from `payload.observation_type`.
+
+    Args:
+        payload: A generic Gundi v2 schema instance (Observation, Event, etc.).
+        route_configuration: The RouteConfiguration carried in the GundiDelivery
+            envelope. May be None.
+        provider_id: The inbound provider's UUID (from delivery.provider).
+        destination_id: The runner's own destination integration UUID.
+
+    Returns:
+        The payload, mutated in place.
+    """
+    rule = _find_rule(
+        route_configuration=route_configuration,
+        payload=payload,
+        provider_id=provider_id,
+        destination_id=destination_id,
+    )
+    if rule:
+        _apply_rule(payload=payload, rule=rule)
+    return payload
+
+
+def _find_rule(
+    *,
+    route_configuration: Optional[RouteConfiguration],
+    payload: BaseModel,
+    provider_id: str,
+    destination_id: str,
+) -> Optional[dict]:
+    if route_configuration is None:
+        return None
+    data = getattr(route_configuration, "data", None) or {}
+    field_mappings = data.get("field_mappings") or {}
+    if not field_mappings:
+        return None
+
+    stream_type = getattr(payload, "observation_type", None)
+    if not stream_type:
+        return None
+
+    rule = (
+        field_mappings.get(str(provider_id), {})
+        .get(str(stream_type), {})
+        .get(str(destination_id), {})
+    )
+    return rule or None
+
+
+def _apply_rule(*, payload: BaseModel, rule: dict) -> None:
+    target = rule.get("destination_field")
+    if not target:
+        return
+
+    if not hasattr(payload, target):
+        # Target is not a field on this payload's model. Likely a destination-runner-
+        # specific value such as EarthRanger's provider_key. Honored elsewhere.
+        logger.warning(
+            "apply_transformations: target '%s' is not a field on %s; skipping rule.",
+            target,
+            type(payload).__name__,
+        )
+        return
+
+    source = rule.get("provider_field")
+    default = rule.get("default")
+    value_map = rule.get("map")
+
+    if not source:
+        if default is not None:
+            setattr(payload, target, default)
+        return
+
+    source_value = _extract_value(payload=payload, source=source)
+    if source_value is None:
+        logger.warning(
+            "apply_transformations: couldn't extract value for source '%s' on %s.",
+            source,
+            type(payload).__name__,
+        )
+        return
+
+    if value_map:
+        resolved = value_map.get(source_value, default)
+    else:
+        resolved = source_value
+
+    setattr(payload, target, resolved)
+
+
+def _extract_value(*, payload: Any, source: str) -> Any:
+    """Walk a `__`-separated path on the payload (mix of attrs and dict keys)."""
+    fields = source.lower().strip().split("__")
+    value: Any = payload
+    for field in fields:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            value = value.get(field)
+        else:
+            value = getattr(value, field, None)
+    return value

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,0 +1,280 @@
+"""Tests for gundi_client_v2.transformations.apply_transformations."""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from gundi_client_v2.transformations import apply_transformations
+from gundi_core.schemas.v2 import (
+    Event,
+    Location,
+    Observation,
+    RouteConfiguration,
+    StreamPrefixEnum,
+    TextMessage,
+)
+
+
+PROVIDER_ID = "11111111-1111-1111-1111-111111111111"
+DESTINATION_ID = "22222222-2222-2222-2222-222222222222"
+OTHER_DESTINATION_ID = "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.fixture
+def event():
+    return Event(
+        source_id=uuid.uuid4(),
+        external_source_id="device-99",
+        recorded_at=datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+        location=Location(lon=-122.0, lat=47.0),
+        title="Sighting",
+        event_type="initial_type",
+        event_details={"species": "lion"},
+    )
+
+
+@pytest.fixture
+def observation():
+    return Observation(
+        source_id=uuid.uuid4(),
+        external_source_id="device-42",
+        source_name="Collar 42",
+        type="tracking-device",
+        recorded_at=datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+        location=Location(lon=-122.0, lat=47.0),
+    )
+
+
+def _route_config(rules: dict) -> RouteConfiguration:
+    return RouteConfiguration(
+        id=uuid.uuid4(),
+        name="Test route config",
+        data={"field_mappings": rules},
+    )
+
+
+def test_no_route_configuration_returns_payload_unchanged(event):
+    original_type = event.event_type
+    result = apply_transformations(
+        event,
+        route_configuration=None,
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert result is event
+    assert result.event_type == original_type
+
+
+def test_empty_field_mappings_returns_payload_unchanged(event):
+    config = _route_config({})
+    apply_transformations(
+        event,
+        route_configuration=config,
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert event.event_type == "initial_type"
+
+
+def test_value_map_translates_event_type_from_species(event):
+    # The 7 real rules in production: read event_details.species, map values,
+    # write to event_type.
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.event.value: {
+                DESTINATION_ID: {
+                    "default": "other_camera_trap",
+                    "provider_field": "event_details__species",
+                    "destination_field": "event_type",
+                    "map": {"lion": "lion_sighting", "leopard": "leopard_sighting"},
+                }
+            }
+        }
+    }
+    apply_transformations(
+        event,
+        route_configuration=_route_config(rules),
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert event.event_type == "lion_sighting"
+
+
+def test_value_map_falls_back_to_default_for_unmapped_value(event):
+    event.event_details = {"species": "elephant"}
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.event.value: {
+                DESTINATION_ID: {
+                    "default": "other_camera_trap",
+                    "provider_field": "event_details__species",
+                    "destination_field": "event_type",
+                    "map": {"lion": "lion_sighting"},
+                }
+            }
+        }
+    }
+    apply_transformations(
+        event,
+        route_configuration=_route_config(rules),
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert event.event_type == "other_camera_trap"
+
+
+def test_default_only_rule_writes_default_to_target(event):
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.event.value: {
+                DESTINATION_ID: {
+                    "default": "trailguard_rep",
+                    "destination_field": "event_type",
+                }
+            }
+        }
+    }
+    apply_transformations(
+        event,
+        route_configuration=_route_config(rules),
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert event.event_type == "trailguard_rep"
+
+
+def test_missing_source_value_logs_and_does_not_mutate(event, caplog):
+    event.event_details = {}
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.event.value: {
+                DESTINATION_ID: {
+                    "default": "other_camera_trap",
+                    "provider_field": "event_details__species",
+                    "destination_field": "event_type",
+                    "map": {"lion": "lion_sighting"},
+                }
+            }
+        }
+    }
+    with caplog.at_level(logging.WARNING):
+        apply_transformations(
+            event,
+            route_configuration=_route_config(rules),
+            provider_id=PROVIDER_ID,
+            destination_id=DESTINATION_ID,
+        )
+    assert event.event_type == "initial_type"  # untouched
+    assert any("couldn't extract value" in r.message.lower() for r in caplog.records)
+
+
+def test_unknown_target_field_logs_and_skips(observation, caplog):
+    # This is exactly the 564 provider_key case — provider_key is not a field
+    # on Observation, so the rule is skipped with a warning.
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.observation.value: {
+                DESTINATION_ID: {
+                    "default": "telonics-collars",
+                    "destination_field": "provider_key",
+                }
+            }
+        }
+    }
+    with caplog.at_level(logging.WARNING):
+        apply_transformations(
+            observation,
+            route_configuration=_route_config(rules),
+            provider_id=PROVIDER_ID,
+            destination_id=DESTINATION_ID,
+        )
+    assert not hasattr(observation, "provider_key")
+    assert any("provider_key" in r.message and "skipping" in r.message for r in caplog.records)
+
+
+def test_rule_for_different_destination_is_ignored(event):
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.event.value: {
+                OTHER_DESTINATION_ID: {
+                    "default": "should_not_apply",
+                    "destination_field": "event_type",
+                }
+            }
+        }
+    }
+    apply_transformations(
+        event,
+        route_configuration=_route_config(rules),
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert event.event_type == "initial_type"
+
+
+def test_rule_for_different_stream_type_is_ignored(event):
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.observation.value: {
+                DESTINATION_ID: {
+                    "default": "should_not_apply",
+                    "destination_field": "event_type",
+                }
+            }
+        }
+    }
+    apply_transformations(
+        event,
+        route_configuration=_route_config(rules),
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert event.event_type == "initial_type"
+
+
+def test_route_configuration_with_no_data_attribute_is_safe(event):
+    config = RouteConfiguration(
+        id=uuid.uuid4(),
+        name="empty",
+        data=None,
+    )
+    apply_transformations(
+        event,
+        route_configuration=config,
+        provider_id=PROVIDER_ID,
+        destination_id=DESTINATION_ID,
+    )
+    assert event.event_type == "initial_type"
+
+
+def test_text_message_unknown_target_skipped(caplog):
+    # txt-stream provider_key rules are the other 136 entries in the survey.
+    message = TextMessage(
+        source_id=uuid.uuid4(),
+        external_source_id="device-tx",
+        sender="555-0100",
+        recipients=["dispatch@example.com"],
+        text="Need help",
+        created_at=datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    rules = {
+        PROVIDER_ID: {
+            StreamPrefixEnum.text_message.value: {
+                DESTINATION_ID: {
+                    "default": "inreach-text",
+                    "destination_field": "provider_key",
+                }
+            }
+        }
+    }
+    with caplog.at_level(logging.WARNING):
+        apply_transformations(
+            message,
+            route_configuration=_route_config(rules),
+            provider_id=PROVIDER_ID,
+            destination_id=DESTINATION_ID,
+        )
+    assert not hasattr(message, "provider_key")
+    assert any("skipping" in r.message for r in caplog.records)


### PR DESCRIPTION
This pull request introduces a new transformation utility to the `gundi_client_v2` package that applies route-based field mapping rules to generic Gundi payloads, along with a comprehensive test suite to ensure correct behavior. The main focus is to mirror existing field mapping logic from `cdip-routing` but adapt it for direct mutation of Gundi Pydantic models, handling both mapped and default values, and gracefully skipping or logging rules that don't apply.

Transformation logic implementation:

* Added `apply_transformations` function in `gundi_client_v2/transformations.py` to mutate Gundi v2 schema payloads in place based on `RouteConfiguration.field_mappings` rules, including support for value mapping, default values, and safe handling of unknown fields or missing data.
* Implemented helper functions to find applicable rules and extract nested values from payloads, supporting both attribute and dictionary access patterns.
* Added logging for skipped rules where the destination field does not exist on the payload or when source values cannot be extracted.

Testing and validation:

* Added `tests/test_transformations.py` with extensive pytest-based coverage for the transformation logic, including edge cases (e.g., missing route config, unmapped values, unknown fields, and different stream types or destinations).
* Tests verify correct mutation, logging, and non-mutation in cases where rules should not apply.