### PR TITLE
Add update_integration to v2 client (enables config write-back)

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -861,6 +861,70 @@ class GundiClient:
         data = response.json()
         return Integration.parse_obj(data)
 
+    async def update_integration(self, integration_id: str | UUID, data: dict) -> Integration:
+        """Partially update an Integration via HTTP PATCH.
+
+        Only the fields present in ``data`` are modified; omitted fields
+        retain their current values on the server (standard PATCH
+        semantics).
+
+        To update an action configuration, pass a ``configurations`` list
+        whose entries carry the configuration ``id`` and the new ``data``::
+
+            await client.update_integration(
+                integration_id,
+                {"configurations": [{"id": config_id, "data": {...}}]},
+            )
+
+        See ``update_integration_configuration()`` for a convenience wrapper
+        around that common case.
+
+        Args:
+            integration_id: UUID of the Integration to update.
+            data: Partial dict of fields to update.
+
+        Returns:
+            The updated ``Integration`` object as returned by the API.
+
+        Raises:
+            AuthenticationError: If the OAuth token request fails.
+            GundiAPIError: If the API returns a 4xx/5xx response.
+        """
+        url = f"{self.integrations_endpoint}/{integration_id}/"
+        response = await self._patch(url, data=data)
+        self._raise_for_status(response)
+        return Integration.parse_obj(response.json())
+
+    async def update_integration_configuration(
+        self,
+        integration_id: str | UUID,
+        configuration_id: str | UUID,
+        data: dict,
+    ) -> Integration:
+        """Update a single action configuration's ``data`` on an Integration.
+
+        Convenience wrapper around ``update_integration()`` for the common
+        case of rewriting one action configuration's payload (e.g. updating
+        a destination's field/tag mappings). The configuration is matched by
+        its ``id``; its action binding is left unchanged.
+
+        Args:
+            integration_id: UUID of the Integration that owns the configuration.
+            configuration_id: UUID of the action configuration to update.
+            data: The new ``data`` payload for that configuration.
+
+        Returns:
+            The updated ``Integration`` object as returned by the API.
+
+        Raises:
+            AuthenticationError: If the OAuth token request fails.
+            GundiAPIError: If the API returns a 4xx/5xx response.
+        """
+        return await self.update_integration(
+            integration_id,
+            {"configurations": [{"id": str(configuration_id), "data": data}]},
+        )
+
     async def get_integration_api_key(self, integration_id: str | UUID) -> Optional[str]:
         """Return the API key string for an Integration.
 

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -884,7 +884,12 @@ class GundiClient:
             data: Partial dict of fields to update.
 
         Returns:
-            The updated ``Integration`` object as returned by the API.
+            The updated ``Integration``, re-fetched via
+            ``get_integration_details``. (The PATCH response itself is
+            serialized with the write serializer, which renders ``type`` /
+            ``owner`` / action references as bare ids rather than the nested
+            objects the ``Integration`` schema requires — so we re-read the
+            canonical representation instead of parsing the PATCH body.)
 
         Raises:
             AuthenticationError: If the OAuth token request fails.
@@ -893,7 +898,7 @@ class GundiClient:
         url = f"{self.integrations_endpoint}/{integration_id}/"
         response = await self._patch(url, data=data)
         self._raise_for_status(response)
-        return Integration.parse_obj(response.json())
+        return await self.get_integration_details(integration_id)
 
     async def update_integration_configuration(
         self,

--- a/tests/client/test_integrations.py
+++ b/tests/client/test_integrations.py
@@ -1,7 +1,11 @@
+import json
+
 import httpx
 import pytest
 import respx
 from gundi_core.schemas.v2 import Connection, Route, Integration
+
+from gundi_client_v2 import errors
 
 # ToDo: complete tests
 # test_data_provider_details
@@ -53,4 +57,73 @@ async def test_get_webhook_integration_details(
         )
         assert isinstance(integration, Integration)
         assert integration == Integration.parse_obj(webhook_integration_details)
+
+
+@pytest.mark.asyncio
+async def test_update_integration_patches_with_partial_data(
+    auth_token_response, destination_integration_details, gundi_client_v2
+):
+    integration_id = destination_integration_details["id"]
+    patch_payload = {"name": "Renamed Integration"}
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        patch_integration = mock.patch(
+            f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
+        ).respond(status_code=httpx.codes.OK, json=destination_integration_details)
+
+        result = await gundi_client_v2.update_integration(integration_id, data=patch_payload)
+
+        assert isinstance(result, Integration)
+        assert patch_integration.call_count == 1
+        assert patch_integration.calls.last.request.method == "PATCH"
+        sent = json.loads(patch_integration.calls.last.request.content.decode())
+        assert sent == patch_payload
+
+
+@pytest.mark.asyncio
+async def test_update_integration_configuration_builds_configurations_payload(
+    auth_token_response, destination_integration_details, gundi_client_v2
+):
+    integration_id = destination_integration_details["id"]
+    configuration_id = "11111111-1111-1111-1111-111111111111"
+    new_data = {"event_type_to_tag": [{"event_type": "rhino_carcass", "tag_name": "Rhino Carcass"}]}
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        patch_integration = mock.patch(
+            f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
+        ).respond(status_code=httpx.codes.OK, json=destination_integration_details)
+
+        result = await gundi_client_v2.update_integration_configuration(
+            integration_id, configuration_id, data=new_data
+        )
+
+        assert isinstance(result, Integration)
+        assert patch_integration.calls.last.request.method == "PATCH"
+        sent = json.loads(patch_integration.calls.last.request.content.decode())
+        # The convenience wraps the single config update in the configurations list
+        assert sent == {
+            "configurations": [{"id": configuration_id, "data": new_data}]
+        }
+
+
+@pytest.mark.asyncio
+async def test_update_integration_raises_gundi_api_error_on_400(
+    auth_token_response, gundi_client_v2
+):
+    integration_id = "bogus-id"
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post(gundi_client_v2.oauth_token_url).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        mock.patch(
+            f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
+        ).respond(status_code=400, json={"detail": "bad patch"})
+
+        with pytest.raises(errors.GundiAPIError) as exc:
+            await gundi_client_v2.update_integration(integration_id, data={"name": ""})
+        assert exc.value.status_code == 400
 

--- a/tests/client/test_integrations.py
+++ b/tests/client/test_integrations.py
@@ -59,8 +59,26 @@ async def test_get_webhook_integration_details(
         assert integration == Integration.parse_obj(webhook_integration_details)
 
 
+# cdip's write serializer renders type/owner/action as bare PK ids on the PATCH
+# response — NOT the nested objects the Integration schema needs. update_integration
+# must therefore re-read via GET (read serializer) rather than parse the PATCH body.
+# These tests mock both calls with their realistic, differing shapes.
+_WRITE_SERIALIZER_PATCH_RESPONSE = {
+    "id": "338225f3-91f9-4fe1-b013-353a229ce504",
+    "name": "Renamed Integration",
+    "base_url": "https://gundi-load-testing.pamdas.org",
+    "enabled": True,
+    "type": "45c66a61-71e4-4664-a7f2-30d465f87aa6",        # bare PK, not nested
+    "owner": "a1b2c3d4-0000-0000-0000-000000000000",       # bare PK, not nested
+    "configurations": [
+        {"id": "cfg-1", "integration": "338225f3-91f9-4fe1-b013-353a229ce504",
+         "action": "43ec4163-2f40-43fc-af62-bca1db77c06b", "data": {}},  # action bare PK
+    ],
+}
+
+
 @pytest.mark.asyncio
-async def test_update_integration_patches_with_partial_data(
+async def test_update_integration_patches_then_refetches(
     auth_token_response, destination_integration_details, gundi_client_v2
 ):
     integration_id = destination_integration_details["id"]
@@ -69,14 +87,23 @@ async def test_update_integration_patches_with_partial_data(
         mock.post(gundi_client_v2.oauth_token_url).respond(
             status_code=httpx.codes.OK, json=auth_token_response
         )
-        patch_integration = mock.patch(
-            f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
-        ).respond(status_code=httpx.codes.OK, json=destination_integration_details)
+        url = f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
+        # PATCH returns the write-serializer shape (bare PK type/owner/action)...
+        patch_integration = mock.patch(url).respond(
+            status_code=httpx.codes.OK, json=_WRITE_SERIALIZER_PATCH_RESPONSE
+        )
+        # ...so the method re-reads the canonical (nested) representation via GET.
+        get_integration = mock.get(url).respond(
+            status_code=httpx.codes.OK, json=destination_integration_details
+        )
 
         result = await gundi_client_v2.update_integration(integration_id, data=patch_payload)
 
+        # Parses cleanly only because we re-fetch — parsing the PATCH body would raise.
         assert isinstance(result, Integration)
+        assert result == Integration.parse_obj(destination_integration_details)
         assert patch_integration.call_count == 1
+        assert get_integration.call_count == 1
         assert patch_integration.calls.last.request.method == "PATCH"
         sent = json.loads(patch_integration.calls.last.request.content.decode())
         assert sent == patch_payload
@@ -86,16 +113,20 @@ async def test_update_integration_patches_with_partial_data(
 async def test_update_integration_configuration_builds_configurations_payload(
     auth_token_response, destination_integration_details, gundi_client_v2
 ):
+    import uuid
+
     integration_id = destination_integration_details["id"]
-    configuration_id = "11111111-1111-1111-1111-111111111111"
+    configuration_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
     new_data = {"event_type_to_tag": [{"event_type": "rhino_carcass", "tag_name": "Rhino Carcass"}]}
     async with respx.mock(assert_all_called=False) as mock:
         mock.post(gundi_client_v2.oauth_token_url).respond(
             status_code=httpx.codes.OK, json=auth_token_response
         )
-        patch_integration = mock.patch(
-            f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
-        ).respond(status_code=httpx.codes.OK, json=destination_integration_details)
+        url = f"{gundi_client_v2.integrations_endpoint}/{integration_id}/"
+        patch_integration = mock.patch(url).respond(
+            status_code=httpx.codes.OK, json=_WRITE_SERIALIZER_PATCH_RESPONSE
+        )
+        mock.get(url).respond(status_code=httpx.codes.OK, json=destination_integration_details)
 
         result = await gundi_client_v2.update_integration_configuration(
             integration_id, configuration_id, data=new_data
@@ -104,9 +135,10 @@ async def test_update_integration_configuration_builds_configurations_payload(
         assert isinstance(result, Integration)
         assert patch_integration.calls.last.request.method == "PATCH"
         sent = json.loads(patch_integration.calls.last.request.content.decode())
-        # The convenience wraps the single config update in the configurations list
+        # The convenience wraps the single config update in the configurations list,
+        # stringifying the UUID configuration_id.
         assert sent == {
-            "configurations": [{"id": configuration_id, "data": new_data}]
+            "configurations": [{"id": str(configuration_id), "data": new_data}]
         }
 
 


### PR DESCRIPTION
## Summary

The v2 client can read integrations (`get_integration_details`) but had no way to write them back — only routes had update support. This adds integration update, so tools can persist changes (e.g. a destination's field/tag mappings) to Gundi via the API instead of hand-editing in the portal.

## Changes

- **`update_integration(integration_id, data)`** — `PATCH /integrations/{id}/`, mirroring `update_route` (partial-update semantics).
- **`update_integration_configuration(integration_id, configuration_id, data)`** — convenience wrapper for the common case of rewriting a single action configuration's `data` by id. Builds the nested `{"configurations": [{"id": ..., "data": ...}]}` payload that the Gundi API's `update_or_create` expects; leaves the config's action binding unchanged.
- Version `3.2.0` → `3.3.0` (additive).

## API alignment

Verified against the cdip v2 API: `IntegrationsView` is a `ModelViewSet` (supports PATCH), and `IntegrationCreateUpdateSerializer.update()` upserts nested configurations via `update_or_create(id=config_data["id"], defaults=config_data)`. The configuration serializer's `action` is `required=False`, so updating just `{id, data}` leaves the action binding intact — which is exactly what the convenience method sends.

## Testing

`pytest tests` → **87 passed** (3 new). New tests assert PATCH verb + exact request body for both methods, and a 400 → `GundiAPIError` path.

## Motivation

Enables an interactive mapping-scaffold CLI (in `gundi-integration-cmore`) to write the generated `DeliverConfig` back to the CMORE integration after the operator confirms the mappings, closing the loop without a manual portal paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)