### PR TITLE
Bound httpx below 1.0 until the client is ported to its new API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ authors = [
 dependencies = [
     "environs>=9.5,<12",
     "pydantic>=1.10,<2",
-    "httpx>=0.28",
+    # <1: httpx 1.0 removes top-level exports we import (see issue #50);
+    # lift deliberately in a release ported to the httpx 1.0 API.
+    "httpx>=0.28,<1",
     "gundi-core>=1.5.8,<3",
 ]
 


### PR DESCRIPTION
## Summary

`httpx>=0.28` → `httpx>=0.28,<1`. httpx 1.0's slimmed top-level namespace breaks `from httpx import AsyncClient` (client.py:6) at import time. Pre-releases are already on PyPI (`1.0.dev3`); once 1.0 goes stable, every fresh `pip install gundi-client-v2` fails without any flags. The bound holds the line until a release is deliberately ported to the httpx 1.0 API.

Fixes #50

## Test plan

- [x] Full suite in a fresh venv against this branch: 223 passed
- [x] Repro from the issue now passes: `pip install --pre <this-branch>` resolves httpx 0.28.1 (previously 1.0.dev3) and `import gundi_client_v2` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1ZfY6j1VkLHch8J6AggPG