### PR TITLE
Bump version to 3.6.0

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.5.0"
+__version__ = "3.6.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError


### PR DESCRIPTION
Bumps `__version__` from 3.5.0 to 3.6.0 so the next `v3.6.0` tag publishes cleanly to PyPI.

## What's in 3.6.0

Everything on `v2` since the 3.5.0 tag:

- **Bound httpx below 1.0 until the client is ported to its new API** (#51)

## Release steps (after this merges)

1. Tag `v3.6.0` on the merge commit and push it → the `release` workflow publishes to PyPI (Trusted Publishing) and creates the GitHub Release.

_Note: this is a version-bump-only PR; no library code changes._

🤖 Generated with [Claude Code](https://claude.com/claude-code)