### PR TITLE
Fix README: CLI does not auto-load a .env from the working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `SENSORS_API_BASE_URL` | Sensors/routing API base URL (used by `GundiDataSenderClient`) | — |
 | `GUNDI_API_SSL_VERIFY` | Verify SSL certificates | `true` |
 | `LOG_LEVEL` | Logging level (env-only) | `INFO` |
-| `GUNDI_CLIENT_ENVFILE` | Path to a `.env` file to load (env-only; defaults to `.env` in cwd) | — |
+| `GUNDI_CLIENT_ENVFILE` | Path to a `.env` file to load (env-only). If unset, no `.env` is auto-loaded from the working directory. | — |
 
 ### GundiClient constructor kwargs
 
@@ -342,8 +342,10 @@ Authentication reuses the same environment variables as the library (see
 - **Token endpoint** — `OAUTH_ISSUER` (preferred; resolved via OIDC discovery)
   or an explicit `OAUTH_TOKEN_URL`.
 
-`OAUTH_AUDIENCE` is forwarded when set. A `.env` file in the working directory
-is loaded automatically.
+`OAUTH_AUDIENCE` is forwarded when set. A `.env` file in the working directory is
+**not** loaded automatically — point `GUNDI_CLIENT_ENVFILE` at one
+(e.g. `GUNDI_CLIENT_ENVFILE=./dev.env gundi integrations list`) or export the
+variables yourself (direnv, your shell, CI secrets).
 
 ```bash
 # List all integrations (table: ID, NAME, TYPE, ENABLED, STATUS)


### PR DESCRIPTION
## Problem

The README claims a `.env` in the working directory is loaded automatically. It isn't. Surfaced by Copilot's review of #49 and verified end-to-end.

`gundi_client_v2/settings.py` calls environs' `read_env()`. With no explicit path, environs resolves its search start from the **caller's file location** — i.e. the installed `settings.py` under `site-packages` — and walks *up* from there, so it never sees a `.env` in the user's current directory on a normal `pip install`.

**Reproduction:**
```console
$ cd /tmp/somewhere && cat .env
GUNDI_API_BASE_URL=https://example
OAUTH_CLIENT_ID=x
OAUTH_ISSUER=https://issuer.example
OAUTH_CLIENT_SECRET=y
$ gundi integrations list
Error: missing required env vars: GUNDI_API_BASE_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD), OAUTH_ISSUER (or OAUTH_TOKEN_URL)
```
The `.env` was ignored.

## Fix

Documentation only — correct two spots to describe actual behavior:
- The `GUNDI_CLIENT_ENVFILE` env-var table entry (drop the misleading "defaults to `.env` in cwd").
- The CLI auth section: a CWD `.env` is **not** auto-loaded; set `GUNDI_CLIENT_ENVFILE` or export the vars.

Explicit `GUNDI_CLIENT_ENVFILE=/path/to/.env` still works and is now the documented way to load a file.

## Alternative considered (not done here)

We *could* instead change the code so a CWD `.env` loads as users expect (e.g. `find_dotenv(usecwd=True)`). I chose the doc fix because auto-loading `.env` files that existing installs currently ignore would be a silent behavior change. Happy to switch to the code approach if preferred — say the word and I'll open that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)