### PR TITLE
Load a .env from the working directory

### DIFF
--- a/.claude/skills/using-the-gundi-cli/SKILL.md
+++ b/.claude/skills/using-the-gundi-cli/SKILL.md
@@ -52,10 +52,11 @@ preferred, or `OAUTH_TOKEN_URL`), and credentials:
 - `GUNDI_USERNAME` + `GUNDI_PASSWORD` (password grant, for developers), **or**
 - `OAUTH_CLIENT_SECRET` (client-credentials, for services).
 
-There is **no automatic `.env` loading from the current directory.** To load a
-file, point `GUNDI_CLIENT_ENVFILE` at its path (e.g.
-`GUNDI_CLIENT_ENVFILE=./dev.env gundi integrations list`), or export the vars
-yourself (direnv, your shell, CI secrets).
+A `.env` in the current directory (or a parent — it walks up) is **loaded
+automatically**. To load a specific file instead, point `GUNDI_CLIENT_ENVFILE`
+at its path (e.g. `GUNDI_CLIENT_ENVFILE=./dev.env gundi integrations list`); it
+takes precedence over a discovered `.env`. Real environment variables always
+win over both.
 
 Selection precedence: `--profile` → `GUNDI_PROFILE` → active env → raw env vars.
 

--- a/gundi_client_v2/settings.py
+++ b/gundi_client_v2/settings.py
@@ -8,8 +8,12 @@ env = Env()
 if envfile:
     env.read_env(envfile)
 else:
-    # Default behavior
-    env.read_env()
+    # Pass a bare filename (not the no-arg form): environs' no-arg read_env()
+    # resolves the .env relative to THIS file's directory (site-packages on a
+    # normal install), so a project-local .env is never found. Given a bare
+    # filename it instead searches from the current working directory, walking
+    # up the tree — matching how other dotenv-based tools behave.
+    env.read_env(".env")
 
 # OAuth settings — OAUTH_* preferred; KEYCLOAK_* accepted for backward compatibility.
 # The token URL is either set directly via OAUTH_TOKEN_URL or discovered at runtime

--- a/tests/client/test_settings.py
+++ b/tests/client/test_settings.py
@@ -39,3 +39,42 @@ def test_oauth_token_url_no_longer_derived_from_issuer(monkeypatch, tmp_path):
     reloaded = importlib.reload(settings_module)
     assert reloaded.OAUTH_ISSUER == "https://idp.example.com/realms/x"
     assert reloaded.OAUTH_TOKEN_URL is None
+
+
+def test_dotenv_in_cwd_is_loaded(monkeypatch, tmp_path):
+    """A `.env` in the current working directory is auto-loaded when
+    GUNDI_CLIENT_ENVFILE is unset (environs' default resolves from the installed
+    package dir, not the caller's cwd — so we must find it from cwd explicitly)."""
+    monkeypatch.delenv("GUNDI_CLIENT_ENVFILE", raising=False)
+    monkeypatch.delenv("GUNDI_API_BASE_URL", raising=False)
+    (tmp_path / ".env").write_text(
+        "GUNDI_API_BASE_URL=https://from-cwd-dotenv.example\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.GUNDI_API_BASE_URL == "https://from-cwd-dotenv.example"
+
+
+def test_dotenv_found_by_walking_up_from_cwd(monkeypatch, tmp_path):
+    """The `.env` is discovered by walking up from cwd, like other dotenv tools,
+    so running from a subdirectory of the project still picks it up."""
+    monkeypatch.delenv("GUNDI_CLIENT_ENVFILE", raising=False)
+    monkeypatch.delenv("GUNDI_API_BASE_URL", raising=False)
+    (tmp_path / ".env").write_text("GUNDI_API_BASE_URL=https://from-parent.example\n")
+    subdir = tmp_path / "nested" / "deeper"
+    subdir.mkdir(parents=True)
+    monkeypatch.chdir(subdir)
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.GUNDI_API_BASE_URL == "https://from-parent.example"
+
+
+def test_envfile_overrides_cwd_dotenv(monkeypatch, tmp_path):
+    """GUNDI_CLIENT_ENVFILE takes precedence over a `.env` in the cwd."""
+    monkeypatch.delenv("GUNDI_API_BASE_URL", raising=False)
+    (tmp_path / ".env").write_text("GUNDI_API_BASE_URL=https://from-cwd.example\n")
+    explicit = tmp_path / "explicit.env"
+    explicit.write_text("GUNDI_API_BASE_URL=https://from-envfile.example\n")
+    monkeypatch.setenv("GUNDI_CLIENT_ENVFILE", str(explicit))
+    monkeypatch.chdir(tmp_path)
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.GUNDI_API_BASE_URL == "https://from-envfile.example"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,21 @@
-import pytest
-from gundi_client_v2.client import GundiClient, GundiDataSenderClient
+import os
+import tempfile
+
+# Neutralize project-local `.env` auto-loading for the whole test session.
+# `gundi_client_v2.settings` loads a `.env` (discovered from the cwd, walking up)
+# at import time, so a developer's local `.env` in or above the repo could leak
+# into os.environ before any per-test monkeypatch isolation runs. Point
+# GUNDI_CLIENT_ENVFILE at an empty file (respecting an explicit override). This
+# MUST run before the first gundi_client_v2 import below.
+os.environ.setdefault(
+    "GUNDI_CLIENT_ENVFILE",
+    tempfile.NamedTemporaryFile(
+        prefix="gundi-empty-", suffix=".env", delete=False
+    ).name,
+)
+
+import pytest  # noqa: E402
+from gundi_client_v2.client import GundiClient, GundiDataSenderClient  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import tempfile
 # into os.environ before any per-test monkeypatch isolation runs. Point
 # GUNDI_CLIENT_ENVFILE at an empty file (respecting an explicit override). This
 # MUST run before the first gundi_client_v2 import below.
-if "GUNDI_CLIENT_ENVFILE" not in os.environ:
+if not os.environ.get("GUNDI_CLIENT_ENVFILE"):
     _fd, _empty_env = tempfile.mkstemp(prefix="gundi-empty-", suffix=".env")
     os.close(_fd)
     os.environ["GUNDI_CLIENT_ENVFILE"] = _empty_env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,10 @@ import tempfile
 # into os.environ before any per-test monkeypatch isolation runs. Point
 # GUNDI_CLIENT_ENVFILE at an empty file (respecting an explicit override). This
 # MUST run before the first gundi_client_v2 import below.
-os.environ.setdefault(
-    "GUNDI_CLIENT_ENVFILE",
-    tempfile.NamedTemporaryFile(
-        prefix="gundi-empty-", suffix=".env", delete=False
-    ).name,
-)
+if "GUNDI_CLIENT_ENVFILE" not in os.environ:
+    _fd, _empty_env = tempfile.mkstemp(prefix="gundi-empty-", suffix=".env")
+    os.close(_fd)
+    os.environ["GUNDI_CLIENT_ENVFILE"] = _empty_env
 
 import pytest  # noqa: E402
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient  # noqa: E402


### PR DESCRIPTION
## Problem

The README claims a `.env` in the working directory is loaded automatically — but it wasn't. `settings.py` called environs' no-arg `read_env()`, which resolves the `.env` path relative to **`settings.py`'s own directory** (`site-packages` on a normal install) and walks up from there, so a project-local `.env` was never found.

Verified before the fix — running `gundi` from a dir with a complete `.env`:
```
Error: missing required env vars: GUNDI_API_BASE_URL, OAUTH_CLIENT_ID, ...
```
The `.env` was ignored. (This supersedes #53, which just documented the limitation.)

## Fix

One line in `settings.py`: pass a **bare filename** to `read_env(".env")`. environs treats a bare filename specially — it searches from the **current working directory** and walks up the tree (the behavior other dotenv tools have). No new dependency; uses environs' own recursion.

- `GUNDI_CLIENT_ENVFILE` still takes precedence over a discovered `.env`.
- Real environment variables still win over the `.env` (no `override`).

## Tests (TDD)

Added to `tests/client/test_settings.py`, written red-first:
- `test_dotenv_in_cwd_is_loaded` — a `.env` in cwd is picked up.
- `test_dotenv_found_by_walking_up_from_cwd` — discovered from a subdirectory.
- `test_envfile_overrides_cwd_dotenv` — `GUNDI_CLIENT_ENVFILE` wins.

Full suite: 226 passed; `black --check` clean.

**End-to-end verified:** running `gundi` from a dir with a `.env` now reads it (proceeds to OIDC discovery against the `.env`'s issuer instead of erroring on missing vars).

## Docs

The original README was already correct once the code works, so it's unchanged. The `using-the-gundi-cli` skill (merged in #49) had documented the *old broken* behavior — updated here to say the `.env` is auto-loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)