### PR TITLE
Bump version to 3.6.1

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.6.0"
+__version__ = "3.6.1"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError


### PR DESCRIPTION
Bumps `__version__` from 3.6.0 to 3.6.1 so the next `v3.6.1` tag publishes cleanly to PyPI.

## What's in 3.6.1

- **Load a `.env` from the working directory** (#54) — `settings.py` now discovers a `.env` from the cwd (walking up), matching the documented behavior. Previously it resolved relative to the installed package dir and silently ignored a project-local `.env`. `GUNDI_CLIENT_ENVFILE` still takes precedence; real env vars still win.

Version-bump-only PR; no other code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)