### PR TITLE
CLI: render a clean error on unparseable API data (no traceback)

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.6.1"
+__version__ = "3.6.2"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/cli/_client.py
+++ b/gundi_client_v2/cli/_client.py
@@ -86,7 +86,8 @@ def build_client() -> GundiClient:
 def run_with_client(async_fn: Callable[[GundiClient], Awaitable[T]]) -> T:
     """Run ``async_fn(client)`` inside an open client, mapping errors to exits.
 
-    AuthenticationError / GundiAPIError are rendered as ``Error: ...`` on stderr
+    AuthenticationError / GundiAPIError, a ValidationError from unparseable API
+    data, and httpx transport errors are rendered as ``Error: ...`` on stderr
     with exit code 1; unexpected exceptions propagate.
     """
     client = build_client()  # may raise typer.Exit(2)
@@ -101,8 +102,11 @@ def run_with_client(async_fn: Callable[[GundiClient], Awaitable[T]]) -> T:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1)
     except ValidationError as exc:
+        # pydantic's ValidationError str is multi-line; collapse it so the CLI
+        # keeps its single-line "Error: ..." contract.
+        detail = " ".join(str(exc).split())
         typer.echo(
-            f"Error: the Gundi API returned data the client could not parse: {exc}",
+            f"Error: the Gundi API returned data the client could not parse: {detail}",
             err=True,
         )
         raise typer.Exit(1)
@@ -273,8 +277,11 @@ def run_command(
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1)
     except ValidationError as exc:
+        # pydantic's ValidationError str is multi-line; collapse it so the CLI
+        # keeps its single-line "Error: ..." contract.
+        detail = " ".join(str(exc).split())
         typer.echo(
-            f"Error: the Gundi API returned data the client could not parse: {exc}",
+            f"Error: the Gundi API returned data the client could not parse: {detail}",
             err=True,
         )
         raise typer.Exit(1)

--- a/gundi_client_v2/cli/_client.py
+++ b/gundi_client_v2/cli/_client.py
@@ -12,6 +12,7 @@ from typing import Awaitable, Callable, Optional, TypeVar
 
 import httpx
 import typer
+from pydantic import ValidationError
 
 from gundi_client_v2 import GundiClient
 from gundi_client_v2.errors import AuthenticationError, GundiAPIError
@@ -98,6 +99,12 @@ def run_with_client(async_fn: Callable[[GundiClient], Awaitable[T]]) -> T:
         return asyncio.run(_runner())
     except (AuthenticationError, GundiAPIError) as exc:
         typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+    except ValidationError as exc:
+        typer.echo(
+            f"Error: the Gundi API returned data the client could not parse: {exc}",
+            err=True,
+        )
         raise typer.Exit(1)
     except httpx.HTTPError as exc:
         typer.echo(f"Error: request failed: {exc}", err=True)
@@ -264,6 +271,12 @@ def run_command(
         raise typer.Exit(1)
     except GundiAPIError as exc:
         typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+    except ValidationError as exc:
+        typer.echo(
+            f"Error: the Gundi API returned data the client could not parse: {exc}",
+            err=True,
+        )
         raise typer.Exit(1)
     except httpx.HTTPError as exc:
         typer.echo(f"Error: request failed: {exc}", err=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1274,5 +1274,8 @@ def test_list_by_type_clean_error_on_unparseable_type(
 
     assert result.exit_code == 1, result.output
     assert "Error:" in result.output
-    # The pydantic ValidationError must be handled, not propagated as a traceback.
+    # The clean-error message contract, on one line, with no traceback leaked.
+    assert "could not parse" in result.output
+    assert "Traceback" not in result.output
+    # The pydantic ValidationError must be handled, not propagated.
     assert not isinstance(result.exception, ValidationError), result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1247,3 +1247,32 @@ def test_logs_filters_forwarded_on_type_path(
     last = logs_route.calls.last.request.url.params
     assert last["log_level"] == "40"
     assert "integration__in" in last
+
+
+def test_list_by_type_clean_error_on_unparseable_type(
+    cli_env, auth_token_response, destination_integration_details
+):
+    # A type whose `value` violates gundi_core's slug regex (^[a-z0-9_]+$) makes
+    # parse_obj_as(List[IntegrationType], ...) raise while resolving --type. One
+    # bad type must surface a clean CLI error (exit 1), not a raw traceback.
+    from pydantic import ValidationError
+
+    good_type = destination_integration_details["type"]
+    bad_type = {
+        **good_type,
+        "id": "9f000000-0000-0000-0000-0000000000bd",
+        "name": "Kenwood Radios",
+        "value": "kenwood-radios",  # hyphen -> fails ^[a-z0-9_]+$
+    }
+    with respx.mock(assert_all_called=False) as mock:
+        _mock_auth(mock, auth_token_response)
+        mock.get(TYPES_URL).respond(
+            status_code=httpx.codes.OK,
+            json={"results": [good_type, bad_type], "next": None},
+        )
+        result = runner.invoke(app, ["integrations", "list", "--type", "earth_ranger"])
+
+    assert result.exit_code == 1, result.output
+    assert "Error:" in result.output
+    # The pydantic ValidationError must be handled, not propagated as a traceback.
+    assert not isinstance(result.exception, ValidationError), result.output


### PR DESCRIPTION
## Problem

`gundi integrations list --type <slug>` (and `integrations types`) crash with a raw pydantic traceback when the portal has an integration type whose slug `value` violates `gundi_core`'s regex `^[a-z0-9_]+$` — e.g. a hyphen or uppercase slug. Because `get_integration_types()` parses a whole page at once, one bad type aborts the stream, and `run_command` / `run_with_client` didn't catch `ValidationError`, so the user saw a stack trace.

Real-world: this happens on **stage** (test types like `kenwood-radios`, `marcosIntegrationType`). **Prod is clean** — all 83 types conform to `^[a-z0-9_]+$`.

## Fix

Catch `pydantic.ValidationError` in both `run_command` and `run_with_client` and render:

```
Error: the Gundi API returned data the client could not parse: <detail>
```

with exit code 1 — the CLI's normal clean-error contract, no traceback.

## Test

`tests/test_cli.py::test_list_by_type_clean_error_on_unparseable_type` — mocks a types page containing a hyphenated slug, asserts exit 1, an `Error:` message, and that the `ValidationError` is handled (not propagated). Full suite: 227 passed; `black` clean.

Bumps version to **3.6.2**.

## Note / follow-up

This is defense/UX only — a bad slug is skipped-with-error rather than crashing, but you still can't `--type` it. The **root prevention** is server-side: cdip's `IntegrationTypeIdempotentCreateSerializer.validate_value` is a no-op and `update_or_create` bypasses the model `SlugField`, so the API accepts any string as a slug. Tightening that (and cleaning the stage test types) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)