### PR TITLE
CLI: use the server-side integration_type log filter (GUNDI-5495)

### DIFF
--- a/.claude/skills/using-the-gundi-cli/SKILL.md
+++ b/.claude/skills/using-the-gundi-cli/SKILL.md
@@ -112,6 +112,12 @@ gundi integrations enable  338225f3-...
   `/v2/logs/?integration_type=` filter) — no id-gathering. Unlike `list --type`,
   it does *not* validate the slug client-side, so an unknown/typo'd slug returns
   no logs rather than an error.
+- **`logs --type` requires the server-side filter to be deployed.** It relies on
+  the portal supporting `/v2/logs/?integration_type=`. An **older portal silently
+  ignores the unknown param and returns _unfiltered_ logs** (all types) — so if
+  `logs --type X` looks like it's returning everything, that portal predates the
+  filter. There's no client-side detection (an ignored param still returns HTTP
+  200), so treat unexpectedly broad `--type` output as "filter not deployed here."
 - **Client-credentials grant has no refresh token.** Password-grant envs refresh
   transparently. A client-credentials env can't *refresh*, but it will
   *re-authenticate* automatically when `OAUTH_CLIENT_SECRET` is present in the
@@ -130,5 +136,6 @@ gundi integrations enable  338225f3-...
 `0` success · `1` API/auth error (clean `Error: …`, no traceback) · `2` missing
 or invalid configuration (bad env, unknown **`list --type`** slug, bad
 `--level`/date, etc.). Note `logs --type <unknown-slug>` is *not* an error — it
-resolves server-side and returns exit `0` with no logs. Scripts can branch on
-these.
+resolves server-side and returns exit `0` with no logs (assuming the
+`integration_type` filter is deployed; an older portal ignores it and returns
+exit `0` with *unfiltered* logs). Scripts can branch on these.

--- a/.claude/skills/using-the-gundi-cli/SKILL.md
+++ b/.claude/skills/using-the-gundi-cli/SKILL.md
@@ -108,9 +108,10 @@ gundi integrations enable  338225f3-...
   integration's **UUID** — get it from `list`.
 - **`logs` needs exactly one target:** either a positional `<uuid>` **or**
   `--type <slug>`, not both and not neither (exits 2).
-- **`logs --type` can be slow / large.** There's no server-side type filter yet
-  (tracked in GUNDI-5409), so the CLI gathers every integration of the type and
-  merges their logs. Prefer a single `<uuid>` when you know it.
+- **`logs --type <slug>` is filtered server-side** in one request (the
+  `/v2/logs/?integration_type=` filter) — no id-gathering. Unlike `list --type`,
+  it does *not* validate the slug client-side, so an unknown/typo'd slug returns
+  no logs rather than an error.
 - **Client-credentials grant has no refresh token.** Password-grant envs refresh
   transparently. A client-credentials env can't *refresh*, but it will
   *re-authenticate* automatically when `OAUTH_CLIENT_SECRET` is present in the

--- a/.claude/skills/using-the-gundi-cli/SKILL.md
+++ b/.claude/skills/using-the-gundi-cli/SKILL.md
@@ -128,5 +128,7 @@ gundi integrations enable  338225f3-...
 ## Exit codes
 
 `0` success · `1` API/auth error (clean `Error: …`, no traceback) · `2` missing
-or invalid configuration (bad env, unknown type slug, bad `--level`/date, etc.).
-Scripts can branch on these.
+or invalid configuration (bad env, unknown **`list --type`** slug, bad
+`--level`/date, etc.). Note `logs --type <unknown-slug>` is *not* an error — it
+resolves server-side and returns exit `0` with no logs. Scripts can branch on
+these.

--- a/gundi_client_v2/cli/integrations.py
+++ b/gundi_client_v2/cli/integrations.py
@@ -175,7 +175,9 @@ def integration_logs(
         target = (
             {"integration": integration_id}
             if integration_type is None
-            else {"integration_type": integration_type}
+            # Slugs are lowercase by convention; normalize client-side so the
+            # match is case-insensitive regardless of the server filter.
+            else {"integration_type": integration_type.lower()}
         )
         return await _fetch_logs(client, {**target, **filters}, limit)
 

--- a/gundi_client_v2/cli/integrations.py
+++ b/gundi_client_v2/cli/integrations.py
@@ -1,7 +1,7 @@
 """`gundi integrations` commands: list, enable, disable."""
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List, Optional
 
 import typer
@@ -169,29 +169,15 @@ def integration_logs(
         filters["to_date"] = _validate_date(until, "--until")
 
     async def _fetch(client):
-        if integration_type is None:
-            return await _fetch_logs(
-                client, {"integration": integration_id, **filters}, limit
-            )
-        # By type: there's no type filter on logs, so gather the type's
-        # integration ids and filter by `integration__in`. The ids are chunked
-        # across requests so the query string stays under the server's
-        # request-line limit, then merged newest-first.
-        type_id = await _resolve_type_id(client, integration_type)
-        ids = [
-            str(i.id) async for i in client.get_integrations(params={"type": type_id})
-        ]
-        if not ids:
-            return []
-        collected = []
-        for chunk in _chunked(ids, _INTEGRATION_IN_CHUNK):
-            collected.extend(
-                await _fetch_logs(
-                    client, {"integration__in": ",".join(chunk), **filters}, limit
-                )
-            )
-        collected.sort(key=_log_created_at, reverse=True)
-        return collected[:limit]
+        # One target key: a specific integration id, or the type slug — the
+        # /v2/logs/ endpoint filters by type slug server-side
+        # (?integration_type=<slug>), so no id-gathering or chunking is needed.
+        target = (
+            {"integration": integration_id}
+            if integration_type is None
+            else {"integration_type": integration_type}
+        )
+        return await _fetch_logs(client, {**target, **filters}, limit)
 
     logs = run_command(profile, _fetch)
 
@@ -229,17 +215,6 @@ def _render_table(integrations: List[Integration]) -> str:
         for i in integrations
     ]
     return _format_table(header, rows)
-
-
-# Integration ids per `integration__in` request. UUIDs are 36 chars + a comma,
-# so 40 keeps the query well under the server's 2048-byte request-line limit.
-_INTEGRATION_IN_CHUNK = 40
-
-
-def _chunked(items: list, size: int):
-    """Yield successive ``size``-length slices of ``items``."""
-    for start in range(0, len(items), size):
-        yield items[start : start + size]
 
 
 async def _fetch_logs(client, params: dict, limit: int) -> list:
@@ -291,23 +266,6 @@ def _validate_date(value: str, flag: str) -> str:
         )
         raise typer.Exit(2)
     return value
-
-
-def _log_created_at(log: dict) -> datetime:
-    """Parse a log's ``created_at`` to a tz-aware datetime for sorting.
-
-    Falls back to the epoch minimum so unparseable timestamps sort last.
-    """
-    raw = log.get("created_at") or ""
-    try:
-        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except (ValueError, TypeError, AttributeError):
-        return datetime.min.replace(tzinfo=timezone.utc)
-    # A timestamp without an offset parses as naive; force UTC so it stays
-    # comparable with the tz-aware fallback (and other tz-aware timestamps).
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed
 
 
 def _log_level_name(level) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -706,21 +706,12 @@ def test_logs_json(cli_env, auth_token_response):
     assert parsed[0]["title"] == "Action started"
 
 
-def test_logs_by_type_uses_integration_in(
-    cli_env, auth_token_response, destination_integration_details
-):
-    type_payload = destination_integration_details["type"]
-    integration_id = destination_integration_details["id"]
+def test_logs_by_type_uses_server_filter(cli_env, auth_token_response):
+    # --type filters server-side via ?integration_type=<slug> in ONE request:
+    # no types lookup, no id-gathering, no integration__in chunking.
+    integration_id = "338225f3-91f9-4fe1-b013-353a229ce504"
     with respx.mock(assert_all_called=False) as mock:
         _mock_auth(mock, auth_token_response)
-        mock.get(TYPES_URL).respond(
-            status_code=httpx.codes.OK,
-            json={"results": [type_payload], "next": None},
-        )
-        mock.get(INTEGRATIONS_URL).respond(
-            status_code=httpx.codes.OK,
-            json={"results": [destination_integration_details], "next": None},
-        )
         logs_route = mock.get(LOGS_URL).respond(
             status_code=httpx.codes.OK,
             json={
@@ -736,7 +727,9 @@ def test_logs_by_type_uses_integration_in(
         result = runner.invoke(app, ["integrations", "logs", "--type", "earth_ranger"])
 
     assert result.exit_code == 0, result.output
-    assert logs_route.calls.last.request.url.params["integration__in"] == integration_id
+    params = logs_route.calls.last.request.url.params
+    assert params["integration_type"] == "earth_ranger"
+    assert "integration__in" not in params
     assert "INTEGRATION" in result.output
     assert "ER Load Testing" in result.output
 
@@ -775,21 +768,20 @@ def test_logs_rejects_both_targets(cli_env, auth_token_response):
     assert result.exit_code == 2, result.output
 
 
-def test_logs_unknown_type_exits_2(
-    cli_env, auth_token_response, destination_integration_details
-):
-    type_payload = destination_integration_details["type"]  # only earth_ranger
+def test_logs_unknown_type_returns_empty(cli_env, auth_token_response):
+    # --type no longer resolves the slug client-side; an unknown/typo'd slug is
+    # forwarded to the server, which returns no logs (not a client-side exit 2).
     with respx.mock(assert_all_called=False) as mock:
         _mock_auth(mock, auth_token_response)
-        mock.get(TYPES_URL).respond(
-            status_code=httpx.codes.OK,
-            json={"results": [type_payload], "next": None},
+        logs_route = mock.get(LOGS_URL).respond(
+            status_code=httpx.codes.OK, json={"results": [], "next": None}
         )
 
         result = runner.invoke(app, ["integrations", "logs", "--type", "nope"])
 
-    assert result.exit_code == 2, result.output
-    assert "unknown integration type" in result.output
+    assert result.exit_code == 0, result.output
+    assert "No activity logs found" in result.output
+    assert logs_route.calls.last.request.url.params["integration_type"] == "nope"
 
 
 def test_logs_empty(cli_env, auth_token_response):
@@ -872,83 +864,6 @@ def test_list_status_composes_with_type_and_enabled(
     assert params["status"] == "unhealthy"
 
 
-def test_logs_by_type_chunks_large_id_set(
-    cli_env, auth_token_response, destination_integration_details
-):
-    # A type with many integrations must not put every id in one
-    # integration__in query (that overruns the server's request-line limit).
-    type_payload = destination_integration_details["type"]
-    ids = [f"00000000-0000-0000-0000-{i:012d}" for i in range(100)]
-    integs = [{**destination_integration_details, "id": uid} for uid in ids]
-    with respx.mock(assert_all_called=False) as mock:
-        _mock_auth(mock, auth_token_response)
-        mock.get(TYPES_URL).respond(
-            status_code=httpx.codes.OK, json={"results": [type_payload], "next": None}
-        )
-        mock.get(INTEGRATIONS_URL).respond(
-            status_code=httpx.codes.OK, json={"results": integs, "next": None}
-        )
-        logs_route = mock.get(LOGS_URL).respond(
-            status_code=httpx.codes.OK, json={"results": [_log_entry()], "next": None}
-        )
-
-        result = runner.invoke(app, ["integrations", "logs", "--type", "earth_ranger"])
-
-    assert result.exit_code == 0, result.output
-    assert logs_route.call_count >= 3  # 100 ids chunked into multiple requests
-    requested = []
-    for call in logs_route.calls:
-        chunk = call.request.url.params["integration__in"].split(",")
-        assert len(chunk) <= 40
-        assert len(str(call.request.url)) < 2048  # under the request-line limit
-        requested.extend(chunk)
-    assert set(requested) == set(ids)  # every integration covered across chunks
-
-
-def test_logs_by_type_sorts_newest_first_and_caps(
-    cli_env, auth_token_response, destination_integration_details
-):
-    type_payload = destination_integration_details["type"]
-    iid = destination_integration_details["id"]
-    with respx.mock(assert_all_called=False) as mock:
-        _mock_auth(mock, auth_token_response)
-        mock.get(TYPES_URL).respond(
-            status_code=httpx.codes.OK, json={"results": [type_payload], "next": None}
-        )
-        mock.get(INTEGRATIONS_URL).respond(
-            status_code=httpx.codes.OK,
-            json={"results": [destination_integration_details], "next": None},
-        )
-        mock.get(LOGS_URL).respond(
-            status_code=httpx.codes.OK,
-            json={
-                "results": [
-                    _log_entry(
-                        id="n",
-                        created_at="2026-06-12T10:00:00Z",
-                        title="Newer",
-                        integration={"id": iid, "name": "ER"},
-                    ),
-                    _log_entry(
-                        id="o",
-                        created_at="2026-06-12T08:00:00Z",
-                        title="Older",
-                        integration={"id": iid, "name": "ER"},
-                    ),
-                ],
-                "next": None,
-            },
-        )
-
-        result = runner.invoke(
-            app, ["integrations", "logs", "--type", "earth_ranger", "--limit", "1"]
-        )
-
-    assert result.exit_code == 0, result.output
-    assert "Newer" in result.output
-    assert "Older" not in result.output
-
-
 def test_list_transport_error_exits_1_clean(cli_env, auth_token_response):
     # A transport-level failure (e.g. connection dropped) must be a clean
     # Error + exit 1, not an uncaught traceback.
@@ -993,29 +908,6 @@ def test_not_authenticated_message_includes_reason(tmp_path, monkeypatch):
     assert "not authenticated" in result.output.lower()
     assert "gundi auth login" in result.output.lower()
     assert "credentials" in result.output.lower()  # underlying reason surfaced
-
-
-def test_log_created_at_naive_timestamp_is_made_utc():
-    from datetime import timezone
-    from gundi_client_v2.cli.integrations import _log_created_at
-
-    # API omitted the tz offset -> must still return a tz-aware datetime.
-    parsed = _log_created_at({"created_at": "2026-06-12T10:00:00"})
-    assert parsed.tzinfo is not None
-    assert parsed.utcoffset() == timezone.utc.utcoffset(None)
-
-
-def test_log_created_at_sorts_naive_and_unparseable_without_crash():
-    from gundi_client_v2.cli.integrations import _log_created_at
-
-    logs = [
-        {"created_at": "2026-06-12T10:00:00"},  # naive
-        {"created_at": "2026-06-12T09:00:00Z"},  # tz-aware
-        {"created_at": "not-a-date"},  # falls back to epoch-min UTC
-    ]
-    # Must not raise "can't compare offset-naive and offset-aware datetimes".
-    ordered = sorted(logs, key=_log_created_at, reverse=True)
-    assert ordered[0]["created_at"] == "2026-06-12T10:00:00"
 
 
 def test_logs_rejects_non_positive_limit(cli_env):
@@ -1217,20 +1109,10 @@ def test_logs_invalid_date_exits_2(cli_env):
     assert "date" in result.output.lower()
 
 
-def test_logs_filters_forwarded_on_type_path(
-    cli_env, auth_token_response, destination_integration_details
-):
-    type_payload = destination_integration_details["type"]
-    integration_id = destination_integration_details["id"]
+def test_logs_filters_forwarded_on_type_path(cli_env, auth_token_response):
+    integration_id = "338225f3-91f9-4fe1-b013-353a229ce504"
     with respx.mock(assert_all_called=False) as mock:
         _mock_auth(mock, auth_token_response)
-        mock.get(TYPES_URL).respond(
-            status_code=httpx.codes.OK, json={"results": [type_payload], "next": None}
-        )
-        mock.get(INTEGRATIONS_URL).respond(
-            status_code=httpx.codes.OK,
-            json={"results": [destination_integration_details], "next": None},
-        )
         logs_route = mock.get(LOGS_URL).respond(
             status_code=httpx.codes.OK,
             json={
@@ -1246,7 +1128,7 @@ def test_logs_filters_forwarded_on_type_path(
     assert result.exit_code == 0, result.output
     last = logs_route.calls.last.request.url.params
     assert last["log_level"] == "40"
-    assert "integration__in" in last
+    assert last["integration_type"] == "earth_ranger"
 
 
 def test_list_by_type_clean_error_on_unparseable_type(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1161,3 +1161,19 @@ def test_list_by_type_clean_error_on_unparseable_type(
     assert "Traceback" not in result.output
     # The pydantic ValidationError must be handled, not propagated.
     assert not isinstance(result.exception, ValidationError), result.output
+
+
+def test_logs_by_type_slug_is_lowercased(cli_env, auth_token_response):
+    # Slugs are lowercase by convention; normalize client-side so `--type
+    # Earth_Ranger` matches regardless of the server filter's case handling.
+    with respx.mock(assert_all_called=False) as mock:
+        _mock_auth(mock, auth_token_response)
+        logs_route = mock.get(LOGS_URL).respond(
+            status_code=httpx.codes.OK, json={"results": [], "next": None}
+        )
+        result = runner.invoke(app, ["integrations", "logs", "--type", "Earth_Ranger"])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        logs_route.calls.last.request.url.params["integration_type"] == "earth_ranger"
+    )


### PR DESCRIPTION
Closes GUNDI-5495. Follow-up to GUNDI-5409 / [cdip#446](https://github.com/PADAS/cdip/pull/446).

## What

`gundi integrations logs --type <slug>` now issues a **single server-filtered request** (`GET /v2/logs/?integration_type=<slug>`) instead of the old workaround: resolve the slug → gather every integration id of the type → chunk `integration__in` (40/request) → merge newest-first client-side.

Net **−159 lines**. Removes the now-dead helpers `_chunked`, `_INTEGRATION_IN_CHUNK`, `_log_created_at`, and the unused `timezone` import. (`_resolve_type_id` stays — `list --type` still resolves the slug→UUID client-side.)

## Behavior change

An unknown/typo'd `--type` slug now returns **no logs** (the server filter yields an empty set) instead of a client-side `exit 2 "unknown integration type"`. Documented in the `using-the-gundi-cli` skill.

## ⚠️ Release gate — server filter must be deployed first

This drops the id-gathering fallback, so `logs --type` is correct **only against a portal where the `/v2/logs/?integration_type=` filter is deployed**. cdip #446 is merged to `main` but deployment to prod/stage is separate. **If a targeted portal doesn't have the filter, an unknown param is silently ignored → `logs --type` would return _unfiltered_ logs.** Do not tag/release this until the server filter is confirmed deployed to prod (and stage). No version bump in this PR for that reason.

## Tests

`tests/test_cli.py`: rewrote `test_logs_by_type_uses_server_filter` (asserts one request with `integration_type=`, no `integration__in`); removed the chunking/merge and `_log_created_at` tests; `logs --type nope` now asserts empty result. Full suite **223 passing**, black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)