### PR TITLE
Bump version to 3.6.3

### DIFF
--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.6.2"
+__version__ = "3.6.3"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError


### PR DESCRIPTION
Bumps `__version__` 3.6.2 → 3.6.3 so the next `v3.6.3` tag publishes.

## What's in 3.6.3

- **CLI: `logs --type` uses the server-side `integration_type` filter** (GUNDI-5495, #57) — one request instead of id-gathering + `integration__in` chunking.

Version-bump-only PR.

_Note: the server-side filter is deployed to **stage**, not yet prod. `logs --type` against a portal without the filter returns unfiltered logs (documented in the skill). Releasing now is acceptable because the CLI has a single, informed user._

🤖 Generated with [Claude Code](https://claude.com/claude-code)