### PR TITLE
Prefer GUNDI_OAUTH_* env var names with silent fallback

### DIFF
--- a/.claude/skills/using-the-gundi-cli/SKILL.md
+++ b/.claude/skills/using-the-gundi-cli/SKILL.md
@@ -44,13 +44,16 @@ Only the **secret/password** is ever prompted. The **username is not prompted** 
 it comes from the env's stored `--username`, the `--username`/`-u` flag on
 `auth login`, or `GUNDI_USERNAME`. Omit all three and you get client-credentials,
 not password grant. For a service env, skip `--username` and supply
-`OAUTH_CLIENT_SECRET` (via env or prompt) instead.
+`GUNDI_OAUTH_CLIENT_SECRET` (via env or prompt) instead.
 
 **B. Raw env vars (good for one-offs / CI).** Export them and run. Required:
-`GUNDI_API_BASE_URL`, `OAUTH_CLIENT_ID`, a token endpoint (`OAUTH_ISSUER`
-preferred, or `OAUTH_TOKEN_URL`), and credentials:
+`GUNDI_API_BASE_URL`, `GUNDI_OAUTH_CLIENT_ID`, a token endpoint (`GUNDI_OAUTH_ISSUER`
+preferred, or `GUNDI_OAUTH_TOKEN_URL`), and credentials:
 - `GUNDI_USERNAME` + `GUNDI_PASSWORD` (password grant, for developers), **or**
-- `OAUTH_CLIENT_SECRET` (client-credentials, for services).
+- `GUNDI_OAUTH_CLIENT_SECRET` (client-credentials, for services).
+
+The un-prefixed `OAUTH_*` names (and, for the library, the legacy `KEYCLOAK_*`
+names) are still accepted as fallbacks.
 
 A `.env` in the current directory (or a parent — it walks up) is **loaded
 automatically**. To load a specific file instead, point `GUNDI_CLIENT_ENVFILE`
@@ -120,7 +123,7 @@ gundi integrations enable  338225f3-...
   200), so treat unexpectedly broad `--type` output as "filter not deployed here."
 - **Client-credentials grant has no refresh token.** Password-grant envs refresh
   transparently. A client-credentials env can't *refresh*, but it will
-  *re-authenticate* automatically when `OAUTH_CLIENT_SECRET` is present in the
+  *re-authenticate* automatically when `GUNDI_OAUTH_CLIENT_SECRET` is present in the
   environment at command time; without the secret, run `gundi auth login` again
   once the access token expires.
 - **`auth status` reports `valid` from the cached expiry, not real acceptance.**

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,23 @@
 # Migration guide
 
+## 3.7.0 — `GUNDI_OAUTH_*` env var names
+
+The preferred env var names for OAuth configuration are now prefixed with
+`GUNDI_` to avoid collisions with other tools sharing an environment:
+
+| Old (still accepted) | New (preferred) |
+|---|---|
+| `OAUTH_ISSUER` | `GUNDI_OAUTH_ISSUER` |
+| `OAUTH_TOKEN_URL` | `GUNDI_OAUTH_TOKEN_URL` |
+| `OAUTH_CLIENT_ID` | `GUNDI_OAUTH_CLIENT_ID` |
+| `OAUTH_CLIENT_SECRET` | `GUNDI_OAUTH_CLIENT_SECRET` |
+| `OAUTH_AUDIENCE` | `GUNDI_OAUTH_AUDIENCE` |
+| `OAUTH_SCOPE` | `GUNDI_OAUTH_SCOPE` |
+
+No action is required: the old `OAUTH_*` names (and the pre-3.0 `KEYCLOAK_*`
+names, for the library) keep working as silent fallbacks. When both spellings
+are set, the `GUNDI_`-prefixed one wins.
+
 ## Upgrading to 3.0 from 2.x
 
 This release modernizes the OAuth2 implementation, bumps the `httpx` runtime

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Configure the client via environment variables (see [Configuration](#configuration)) or pass values directly. The Quick Start snippet needs more than credentials at runtime — at minimum a `base_url` / `GUNDI_API_BASE_URL`, an `OAUTH_CLIENT_ID`, and either an `OAUTH_ISSUER` or `oauth_token_url`. Example with kwargs:
+Configure the client via environment variables (see [Configuration](#configuration)) or pass values directly. The Quick Start snippet needs more than credentials at runtime — at minimum a `base_url` / `GUNDI_API_BASE_URL`, a `GUNDI_OAUTH_CLIENT_ID`, and either a `GUNDI_OAUTH_ISSUER` or `oauth_token_url`. Example with kwargs:
 
 ```python
 client = GundiClient(
@@ -94,17 +94,19 @@ Settings can be provided as **environment variables** or **constructor keyword a
 |---|---|---|
 | `GUNDI_USERNAME` | Your Gundi username (email) — required for password grant | — |
 | `GUNDI_PASSWORD` | Your Gundi password — required for password grant | — |
-| `OAUTH_CLIENT_ID` | OAuth client ID | — |
-| `OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
-| `OAUTH_ISSUER` | OIDC issuer URL. When set without `OAUTH_TOKEN_URL`, the token endpoint is discovered at runtime from `{OAUTH_ISSUER}/.well-known/openid-configuration`. A trailing slash is normalized. | — |
-| `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, overrides OIDC discovery from `OAUTH_ISSUER`. | — |
-| `OAUTH_AUDIENCE` | OAuth audience. Sent to the token endpoint when set. Required by some IdPs (e.g. Auth0 won't issue a usable API access token without it); ignored by others (Keycloak password grant). | — |
-| `OAUTH_SCOPE` | OAuth scope | `openid` |
+| `GUNDI_OAUTH_CLIENT_ID` | OAuth client ID | — |
+| `GUNDI_OAUTH_CLIENT_SECRET` | OAuth client secret — required for client-credentials grant | — |
+| `GUNDI_OAUTH_ISSUER` | OIDC issuer URL. When set without `GUNDI_OAUTH_TOKEN_URL`, the token endpoint is discovered at runtime from `{GUNDI_OAUTH_ISSUER}/.well-known/openid-configuration`. A trailing slash is normalized. | — |
+| `GUNDI_OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, overrides OIDC discovery from `GUNDI_OAUTH_ISSUER`. | — |
+| `GUNDI_OAUTH_AUDIENCE` | OAuth audience. Sent to the token endpoint when set. Required by some IdPs (e.g. Auth0 won't issue a usable API access token without it); ignored by others (Keycloak password grant). | — |
+| `GUNDI_OAUTH_SCOPE` | OAuth scope | `openid` |
 | `GUNDI_API_BASE_URL` | Gundi API base URL | — |
 | `SENSORS_API_BASE_URL` | Sensors/routing API base URL (used by `GundiDataSenderClient`) | — |
 | `GUNDI_API_SSL_VERIFY` | Verify SSL certificates | `true` |
 | `LOG_LEVEL` | Logging level (env-only) | `INFO` |
 | `GUNDI_CLIENT_ENVFILE` | Path to a `.env` file to load (env-only; defaults to `.env` in cwd) | — |
+
+The un-prefixed `OAUTH_*` names (and, for the library, the legacy `KEYCLOAK_*` names) are still accepted as fallbacks.
 
 ### GundiClient constructor kwargs
 
@@ -114,12 +116,12 @@ Settings can be provided as **environment variables** or **constructor keyword a
 | `use_ssl` | `GUNDI_API_SSL_VERIFY` | Verify SSL certificates |
 | `username` | `GUNDI_USERNAME` | Gundi username |
 | `password` | `GUNDI_PASSWORD` | Gundi password |
-| `oauth_client_id` | `OAUTH_CLIENT_ID` | OAuth client ID |
-| `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | OAuth client secret |
-| `oauth_token_url` | `OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, used as-is. |
-| `oauth_issuer` | `OAUTH_ISSUER` | OIDC issuer URL. When set without `oauth_token_url`, the token endpoint is discovered via OIDC discovery. |
-| `oauth_audience` | `OAUTH_AUDIENCE` | OAuth audience. IdP-dependent — required for Auth0, optional for Keycloak password grant. |
-| `oauth_scope` | `OAUTH_SCOPE` | OAuth scope |
+| `oauth_client_id` | `GUNDI_OAUTH_CLIENT_ID` | OAuth client ID |
+| `oauth_client_secret` | `GUNDI_OAUTH_CLIENT_SECRET` | OAuth client secret |
+| `oauth_token_url` | `GUNDI_OAUTH_TOKEN_URL` | Full OAuth token endpoint URL. When set, used as-is. |
+| `oauth_issuer` | `GUNDI_OAUTH_ISSUER` | OIDC issuer URL. When set without `oauth_token_url`, the token endpoint is discovered via OIDC discovery. |
+| `oauth_audience` | `GUNDI_OAUTH_AUDIENCE` | OAuth audience. IdP-dependent — required for Auth0, optional for Keycloak password grant. |
+| `oauth_scope` | `GUNDI_OAUTH_SCOPE` | OAuth scope |
 | `max_http_retries` | — | Max HTTP retries (default `5`) |
 | `connect_timeout` | — | Connect timeout in seconds (default `3.1`) |
 | `data_timeout` | — | Data timeout in seconds (default `20`) |
@@ -135,30 +137,30 @@ Settings can be provided as **environment variables** or **constructor keyword a
 
 The client supports two authentication modes:
 
-**Password grant (for developers)** — Provide `GUNDI_USERNAME` and `GUNDI_PASSWORD` along with `OAUTH_CLIENT_ID`. This is the recommended approach for external developers.
+**Password grant (for developers)** — Provide `GUNDI_USERNAME` and `GUNDI_PASSWORD` along with `GUNDI_OAUTH_CLIENT_ID`. This is the recommended approach for external developers.
 
-**Client credentials grant (for services)** — Provide `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. This is used by internal backend services.
+**Client credentials grant (for services)** — Provide `GUNDI_OAUTH_CLIENT_ID` and `GUNDI_OAUTH_CLIENT_SECRET`. This is used by internal backend services.
 
 ### Token URL resolution
 
 The client resolves the OAuth token endpoint in this order:
 
-1. **`oauth_token_url` (kwarg) / `OAUTH_TOKEN_URL` (env)** — used as-is when set.
-2. **`oauth_issuer` (kwarg) / `OAUTH_ISSUER` (env)** — the client fetches `{issuer}/.well-known/openid-configuration` (OIDC discovery) and uses its `token_endpoint`. Result is cached for the process lifetime; call `gundi_client_v2.auth.clear_discovery_cache()` to invalidate.
+1. **`oauth_token_url` (kwarg) / `GUNDI_OAUTH_TOKEN_URL` (env)** — used as-is when set.
+2. **`oauth_issuer` (kwarg) / `GUNDI_OAUTH_ISSUER` (env)** — the client fetches `{issuer}/.well-known/openid-configuration` (OIDC discovery) and uses its `token_endpoint`. Result is cached for the process lifetime; call `gundi_client_v2.auth.clear_discovery_cache()` to invalidate.
 3. **Neither set** — `AuthenticationError("No token URL configured. Set oauth_token_url or oauth_issuer.")` is raised on the first auth attempt.
 
-OIDC discovery works for any compliant IdP (Keycloak, Auth0, Okta, …). Configure `OAUTH_ISSUER` and the token endpoint is found automatically.
+OIDC discovery works for any compliant IdP (Keycloak, Auth0, Okta, …). Configure `GUNDI_OAUTH_ISSUER` and the token endpoint is found automatically.
 
 ### Audience
 
-`OAUTH_AUDIENCE` is sent to the token endpoint when configured. Whether it is required depends on the IdP:
+`GUNDI_OAUTH_AUDIENCE` is sent to the token endpoint when configured. Whether it is required depends on the IdP:
 
 - **Auth0** — required. Without `audience`, Auth0 issues an opaque token that cannot authorize API requests.
 - **Keycloak** — optional. Both grant types this library supports (password and client_credentials) ignore it.
 
-The parameter name `audience` reflects the Auth0/Keycloak convention. The OAuth 2.0 / OIDC standard equivalent is `resource` (RFC 8707, *Resource Indicators*). If we add support for IdPs that strictly require `resource` instead, it will be introduced as a `resource` kwarg alongside `audience`, not as a rename. Existing `OAUTH_AUDIENCE` / `oauth_audience` configurations will keep working.
+The parameter name `audience` reflects the Auth0/Keycloak convention. The OAuth 2.0 / OIDC standard equivalent is `resource` (RFC 8707, *Resource Indicators*). If we add support for IdPs that strictly require `resource` instead, it will be introduced as a `resource` kwarg alongside `audience`, not as a rename. Existing `GUNDI_OAUTH_AUDIENCE` / `oauth_audience` configurations will keep working.
 
-> **Backward compatibility:** The legacy `KEYCLOAK_*` env var names (`KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE`) are still accepted as fallbacks for the corresponding `OAUTH_*` env vars. Three legacy constructor kwargs are also still accepted: `keycloak_client_id`, `keycloak_client_secret`, and `keycloak_audience`. There is no `keycloak_issuer` constructor kwarg — use `oauth_token_url` or `oauth_issuer` instead.
+> **Backward compatibility:** The un-prefixed `OAUTH_*` names (and, for the library, the legacy `KEYCLOAK_*` names) are still accepted as fallbacks. Specifically: `OAUTH_ISSUER`, `OAUTH_CLIENT_ID`, `OAUTH_CLIENT_SECRET`, `OAUTH_AUDIENCE`, `OAUTH_TOKEN_URL`, and `OAUTH_SCOPE` all fall back for the corresponding `GUNDI_OAUTH_*` env vars, and the legacy `KEYCLOAK_ISSUER`, `KEYCLOAK_CLIENT_ID`, `KEYCLOAK_CLIENT_SECRET`, `KEYCLOAK_AUDIENCE` fall back after that. Three legacy constructor kwargs are also still accepted: `keycloak_client_id`, `keycloak_client_secret`, and `keycloak_audience`. There is no `keycloak_issuer` constructor kwarg — use `oauth_token_url` or `oauth_issuer` instead. When multiple spellings are set, the `GUNDI_`-prefixed one wins.
 
 If both are configured, password grant takes precedence. Contact the Gundi team for credentials.
 
@@ -335,15 +337,15 @@ pip install "gundi-client-v2[cli]"
 
 Authentication reuses the same environment variables as the library (see
 [Configuration](#configuration)). The CLI needs `GUNDI_API_BASE_URL`,
-`OAUTH_CLIENT_ID`, plus:
+`GUNDI_OAUTH_CLIENT_ID`, plus:
 
 - **Credentials** — either `GUNDI_USERNAME` + `GUNDI_PASSWORD` (password grant,
-  for developers) or `OAUTH_CLIENT_SECRET` (client-credentials, for services).
-- **Token endpoint** — `OAUTH_ISSUER` (preferred; resolved via OIDC discovery)
-  or an explicit `OAUTH_TOKEN_URL`.
+  for developers) or `GUNDI_OAUTH_CLIENT_SECRET` (client-credentials, for services).
+- **Token endpoint** — `GUNDI_OAUTH_ISSUER` (preferred; resolved via OIDC discovery)
+  or an explicit `GUNDI_OAUTH_TOKEN_URL`.
 
-`OAUTH_AUDIENCE` is forwarded when set. A `.env` file in the working directory
-is loaded automatically.
+`GUNDI_OAUTH_AUDIENCE` is forwarded when set. A `.env` file in the working directory
+is loaded automatically. The un-prefixed `OAUTH_*` names are still accepted as fallbacks.
 
 ```bash
 # List all integrations (table: ID, NAME, TYPE, ENABLED, STATUS)
@@ -396,7 +398,7 @@ gundi env list              # '*' marks the active one
 gundi env show prod
 
 # Authenticate once; the token is cached and reused by later commands.
-# The secret/password is read from env (OAUTH_CLIENT_SECRET / GUNDI_PASSWORD)
+# The secret/password is read from env (GUNDI_OAUTH_CLIENT_SECRET / GUNDI_PASSWORD)
 # or prompted (hidden) — and never stored.
 gundi auth login                              # grant chosen by the env's config
 gundi auth login --username me@example.com    # force the password grant
@@ -409,8 +411,8 @@ gundi auth logout
 ```
 
 **Environment selection precedence:** `--profile` flag → `GUNDI_PROFILE` env var
-→ stored active environment → raw `OAUTH_*` / `GUNDI_*` env vars (the original
-behavior, used when no environments are configured).
+→ stored active environment → raw `GUNDI_OAUTH_*` / `OAUTH_*` / `GUNDI_*` env vars
+(the original behavior, used when no environments are configured).
 
 **Token refresh:** password-grant environments refresh transparently using the
 cached refresh token. Client-credentials environments (no refresh token) require

--- a/docs/authentication/client-credentials.md
+++ b/docs/authentication/client-credentials.md
@@ -15,10 +15,10 @@ for **server-to-server** authentication. There is no user identity involved
 
 ```env
 GUNDI_API_BASE_URL=https://api.gundiservice.org
-OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
-OAUTH_CLIENT_ID=your-client-id
-OAUTH_CLIENT_SECRET=your-client-secret
-# OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
+GUNDI_OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
+GUNDI_OAUTH_CLIENT_ID=your-client-id
+GUNDI_OAUTH_CLIENT_SECRET=your-client-secret
+# GUNDI_OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
 ```
 
 ## Minimal example
@@ -47,14 +47,14 @@ The library POSTs to the token endpoint with:
 
 ```
 grant_type=client_credentials
-client_id=<OAUTH_CLIENT_ID>
-client_secret=<OAUTH_CLIENT_SECRET>
+client_id=<GUNDI_OAUTH_CLIENT_ID>
+client_secret=<GUNDI_OAUTH_CLIENT_SECRET>
 scope=openid
-audience=<OAUTH_AUDIENCE>     # only if set
+audience=<GUNDI_OAUTH_AUDIENCE>     # only if set
 ```
 
-The token endpoint is either `OAUTH_TOKEN_URL` directly, or resolved via
-OIDC discovery from `OAUTH_ISSUER`.
+The token endpoint is either `GUNDI_OAUTH_TOKEN_URL` directly, or resolved via
+OIDC discovery from `GUNDI_OAUTH_ISSUER`.
 
 ## Refresh behavior
 

--- a/docs/authentication/oidc-discovery.md
+++ b/docs/authentication/oidc-discovery.md
@@ -6,7 +6,7 @@ document includes the `token_endpoint`, `authorization_endpoint`, supported
 scopes, and other configuration.
 
 `gundi-client-v2` uses this to **avoid hard-coding** the token endpoint URL.
-Set `OAUTH_ISSUER` to the IdP's issuer base URL, and the library fetches and
+Set `GUNDI_OAUTH_ISSUER` to the IdP's issuer base URL, and the library fetches and
 caches the resolved token endpoint at runtime.
 
 ## When to use it
@@ -20,7 +20,7 @@ caches the resolved token endpoint at runtime.
 ## Environment variable
 
 ```env
-OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
+GUNDI_OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
 ```
 
 Combine with the credentials for your chosen grant
@@ -57,11 +57,11 @@ network I/O for discovery.
 ## Skipping discovery
 
 If your IdP doesn't expose a discovery document, or you want to skip the
-extra request, set `OAUTH_TOKEN_URL` directly instead. When both are set,
-`OAUTH_TOKEN_URL` wins:
+extra request, set `GUNDI_OAUTH_TOKEN_URL` directly instead. When both are set,
+`GUNDI_OAUTH_TOKEN_URL` wins:
 
 ```env
-OAUTH_TOKEN_URL=https://auth.example.com/realms/myrealm/protocol/openid-connect/token
+GUNDI_OAUTH_TOKEN_URL=https://auth.example.com/realms/myrealm/protocol/openid-connect/token
 ```
 
 ## Errors

--- a/docs/authentication/overview.md
+++ b/docs/authentication/overview.md
@@ -14,8 +14,11 @@ outgoing request — but they differ in how that token is obtained.
 
 OIDC discovery is **not a separate grant type** — it's a mechanism for the
 library to discover the IdP's token endpoint at runtime from
-`{OAUTH_ISSUER}/.well-known/openid-configuration`. You combine it with one of
+`{GUNDI_OAUTH_ISSUER}/.well-known/openid-configuration`. You combine it with one of
 the other two grants.
+
+The un-prefixed `OAUTH_*` names (and, for the library, the legacy `KEYCLOAK_*`
+names) are still accepted as fallbacks.
 
 ## How the client picks a grant
 
@@ -46,10 +49,10 @@ from gundi_client_v2.auth import (
 The library needs to know **where** to POST the token request. Two ways to
 configure this, in priority order:
 
-1. **`OAUTH_TOKEN_URL`** (or the `oauth_token_url` kwarg) — set this
+1. **`GUNDI_OAUTH_TOKEN_URL`** (or the `oauth_token_url` kwarg) — set this
    directly to a fully-qualified URL like
    `https://auth.example.com/realms/myrealm/protocol/openid-connect/token`.
-2. **`OAUTH_ISSUER`** (or the `oauth_issuer` kwarg) — set this to the
+2. **`GUNDI_OAUTH_ISSUER`** (or the `oauth_issuer` kwarg) — set this to the
    issuer base URL; the library performs OIDC discovery to resolve the token
    endpoint. The result is cached for the process lifetime; call
    `auth.clear_discovery_cache()` to invalidate.

--- a/docs/authentication/password-grant.md
+++ b/docs/authentication/password-grant.md
@@ -22,11 +22,11 @@ to the IdP.
 
 ```env
 GUNDI_API_BASE_URL=https://api.gundiservice.org
-OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
-OAUTH_CLIENT_ID=your-client-id
+GUNDI_OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
+GUNDI_OAUTH_CLIENT_ID=your-client-id
 GUNDI_USERNAME=your-username
 GUNDI_PASSWORD=your-password
-# OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
+# GUNDI_OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
 ```
 
 ## Minimal example
@@ -51,11 +51,11 @@ asyncio.run(main())
 
 ```
 grant_type=password
-client_id=<OAUTH_CLIENT_ID>
+client_id=<GUNDI_OAUTH_CLIENT_ID>
 username=<GUNDI_USERNAME>
 password=<GUNDI_PASSWORD>
 scope=openid
-audience=<OAUTH_AUDIENCE>     # only if set
+audience=<GUNDI_OAUTH_AUDIENCE>     # only if set
 ```
 
 No `client_secret` — public clients don't have one.

--- a/docs/authentication/refresh-and-errors.md
+++ b/docs/authentication/refresh-and-errors.md
@@ -50,8 +50,8 @@ user credentials are involved, this is cheap.
 
 The client ID or secret is wrong, or the client doesn't exist in the realm.
 
-**Fix:** Verify `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`. For Keycloak,
-also confirm the client is in the correct realm under `OAUTH_ISSUER`.
+**Fix:** Verify `GUNDI_OAUTH_CLIENT_ID` and `GUNDI_OAUTH_CLIENT_SECRET`. For Keycloak,
+also confirm the client is in the correct realm under `GUNDI_OAUTH_ISSUER`.
 
 ### `Token request failed: HTTP 401 (invalid_grant)`
 
@@ -78,7 +78,7 @@ client.
 The requested scope isn't allowed for this client.
 
 **Fix:** Pass a `scope=...` kwarg to the grant function, or unset
-`OAUTH_SCOPE` if you set it explicitly. The library's default scope is
+`GUNDI_OAUTH_SCOPE` if you set it explicitly. The library's default scope is
 `openid`.
 
 ### `AuthenticationError: OIDC discovery failed for ...`

--- a/docs/getting-started/auth-setup.md
+++ b/docs/getting-started/auth-setup.md
@@ -20,7 +20,7 @@ detailed coverage of each grant type, see the
 | Use this | When |
 |---|---|
 | `client_credentials` | Server-to-server, no user identity involved. Your client is confidential (has a secret). |
-| `password` | Acting on behalf of a known user with their username and password. `OAUTH_CLIENT_SECRET` is not used by this grant. |
+| `password` | Acting on behalf of a known user with their username and password. `GUNDI_OAUTH_CLIENT_SECRET` is not used by this grant. |
 
 If unsure, ask your Gundi administrator which grant your client is configured
 for.
@@ -34,36 +34,39 @@ shell:
 
     ```env
     GUNDI_API_BASE_URL=https://api.gundiservice.org
-    OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
-    OAUTH_CLIENT_ID=your-client-id
-    OAUTH_CLIENT_SECRET=your-client-secret
-    # OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
+    GUNDI_OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
+    GUNDI_OAUTH_CLIENT_ID=your-client-id
+    GUNDI_OAUTH_CLIENT_SECRET=your-client-secret
+    # GUNDI_OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
     ```
 
 === "password grant"
 
     ```env
     GUNDI_API_BASE_URL=https://api.gundiservice.org
-    OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
-    OAUTH_CLIENT_ID=your-client-id
+    GUNDI_OAUTH_ISSUER=https://auth.gundiservice.org/realms/your-realm
+    GUNDI_OAUTH_CLIENT_ID=your-client-id
     GUNDI_USERNAME=your-username
     GUNDI_PASSWORD=your-password
-    # OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
+    # GUNDI_OAUTH_AUDIENCE=your-api-audience   # required by some IdPs (e.g. Auth0)
     ```
+
+The un-prefixed `OAUTH_*` names (and, for the library, the legacy `KEYCLOAK_*`
+names) are still accepted as fallbacks.
 
 ## How the library uses these
 
 When you create a `GundiClient()` with no arguments, it reads these env vars
-through `gundi_client_v2.settings`. Setting `OAUTH_ISSUER` triggers **OIDC
+through `gundi_client_v2.settings`. Setting `GUNDI_OAUTH_ISSUER` triggers **OIDC
 discovery**: the library fetches the IdP's
 `/.well-known/openid-configuration` document on the first auth attempt and
 caches the resolved token endpoint for the process lifetime.
 
-If your IdP doesn't expose discovery, set `OAUTH_TOKEN_URL` directly instead
-of `OAUTH_ISSUER`.
+If your IdP doesn't expose discovery, set `GUNDI_OAUTH_TOKEN_URL` directly instead
+of `GUNDI_OAUTH_ISSUER`.
 
 !!! tip "Audience parameter"
-    `OAUTH_AUDIENCE` is required by some IdPs (notably Auth0 won't issue a
+    `GUNDI_OAUTH_AUDIENCE` is required by some IdPs (notably Auth0 won't issue a
     usable API access token without it) and ignored by others (Keycloak
     password grant). Set it if your IdP requires it; leave it unset
     otherwise.

--- a/docs/getting-started/first-request.md
+++ b/docs/getting-started/first-request.md
@@ -38,7 +38,7 @@ You should see a connection count and a JSON dump of the first Connection.
 ## What just happened
 
 1. **`GundiClient()`** read your env vars (`GUNDI_API_BASE_URL`,
-   `OAUTH_ISSUER`, and the credentials) into a configured client.
+   `GUNDI_OAUTH_ISSUER`, and the credentials) into a configured client.
 2. **`async with`** opened the underlying HTTPX session. No network
    traffic yet.
 3. **`client.get_connections()`** triggered the first authenticated

--- a/docs/superpowers/plans/2026-07-30-gundi-oauth-env-prefix.md
+++ b/docs/superpowers/plans/2026-07-30-gundi-oauth-env-prefix.md
@@ -1,0 +1,469 @@
+# GUNDI_OAUTH_* Env Var Prefix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `GUNDI_OAUTH_*` the preferred env var names for OAuth config, with silent fallback to the existing `OAUTH_*` (and, in the library, `KEYCLOAK_*`) names.
+
+**Architecture:** Two lookup layers change: `gundi_client_v2/settings.py` (environs-based, used by the library) grows one link at the front of each chain; the CLI (`gundi_client_v2/cli/_client.py`, reads `os.environ` directly) gets a tiny `_getenv()` helper that prefers the `GUNDI_`-prefixed spelling. Docs/examples/error messages switch to the new names. Spec: `docs/superpowers/specs/2026-07-30-gundi-oauth-env-prefix-design.md`.
+
+**Tech Stack:** Python, environs, typer CLI, pytest (+ monkeypatch, respx, CliRunner). Run tests with `uv run pytest`.
+
+## Global Constraints
+
+- New preferred names: `GUNDI_OAUTH_ISSUER`, `GUNDI_OAUTH_TOKEN_URL`, `GUNDI_OAUTH_CLIENT_ID`, `GUNDI_OAUTH_CLIENT_SECRET`, `GUNDI_OAUTH_AUDIENCE`, `GUNDI_OAUTH_SCOPE`.
+- Library fallback chain: `GUNDI_OAUTH_X` → `OAUTH_X` → `KEYCLOAK_X` (no `KEYCLOAK_*` link for `TOKEN_URL`/`SCOPE`; `SCOPE` defaults to `"openid"`).
+- CLI fallback chain: `GUNDI_OAUTH_X` → `OAUTH_X` only (the CLI never accepted `KEYCLOAK_*`).
+- Silent fallback — NO deprecation warnings anywhere.
+- Python constants in `settings.py` keep their `OAUTH_*` names (and the existing `KEYCLOAK_*` aliases). Do not rename module attributes.
+- `LOG_LEVEL` and `SENSORS_API_BASE_URL` are OUT OF SCOPE — do not touch them.
+- Existing old-name tests must stay untouched and passing (they are the back-compat regression suite).
+- Version ships as `3.7.0` (`gundi_client_v2/__init__.py`).
+- Code style: `black` (CI runs `black --check`). Run `uv run black .` before each commit.
+- The `site/` directory is generated mkdocs output — never edit it. Historical files under `docs/superpowers/` are records — never edit them.
+
+---
+
+### Task 1: settings.py lookup chains
+
+**Files:**
+- Modify: `gundi_client_v2/settings.py:18-28`
+- Test: `tests/client/test_settings.py`
+
+**Interfaces:**
+- Consumes: existing `env = Env()` setup and the `_isolate_envfile` / `_restore_settings_after_test` test helpers already in `tests/client/test_settings.py`.
+- Produces: module constants `settings.OAUTH_ISSUER`, `settings.OAUTH_TOKEN_URL`, `settings.OAUTH_CLIENT_ID`, `settings.OAUTH_CLIENT_SECRET`, `settings.OAUTH_AUDIENCE`, `settings.OAUTH_SCOPE` — same names and types as today (str or None; `OAUTH_SCOPE` always str), now also populated from `GUNDI_OAUTH_*`. Task 2 and the library rely on these exact names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/client/test_settings.py` (it already imports `importlib`, `pytest`, and `settings_module`, and defines `_isolate_envfile`):
+
+```python
+_GUNDI_OAUTH_VARS = (
+    "GUNDI_OAUTH_ISSUER",
+    "GUNDI_OAUTH_TOKEN_URL",
+    "GUNDI_OAUTH_CLIENT_ID",
+    "GUNDI_OAUTH_CLIENT_SECRET",
+    "GUNDI_OAUTH_AUDIENCE",
+    "GUNDI_OAUTH_SCOPE",
+)
+
+
+def _clear_oauth_env(monkeypatch):
+    """Drop every spelling of the OAuth vars so precedence tests start clean."""
+    for name in _GUNDI_OAUTH_VARS:
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(name.removeprefix("GUNDI_"), raising=False)
+        monkeypatch.delenv(name.replace("GUNDI_OAUTH_", "KEYCLOAK_"), raising=False)
+
+
+def test_gundi_oauth_names_work_alone(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("GUNDI_OAUTH_ISSUER", "https://idp.example.com/realms/x")
+    monkeypatch.setenv("GUNDI_OAUTH_TOKEN_URL", "https://idp.example.com/token")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_ID", "my-client")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_SECRET", "shhh")
+    monkeypatch.setenv("GUNDI_OAUTH_AUDIENCE", "gundi-api")
+    monkeypatch.setenv("GUNDI_OAUTH_SCOPE", "openid profile")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_ISSUER == "https://idp.example.com/realms/x"
+    assert reloaded.OAUTH_TOKEN_URL == "https://idp.example.com/token"
+    assert reloaded.OAUTH_CLIENT_ID == "my-client"
+    assert reloaded.OAUTH_CLIENT_SECRET == "shhh"
+    assert reloaded.OAUTH_AUDIENCE == "gundi-api"
+    assert reloaded.OAUTH_SCOPE == "openid profile"
+
+
+def test_gundi_oauth_prefix_wins_over_oauth_and_keycloak(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_ID", "prefixed")
+    monkeypatch.setenv("OAUTH_CLIENT_ID", "generic")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "legacy")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_CLIENT_ID == "prefixed"
+
+
+def test_oauth_still_wins_over_keycloak(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("OAUTH_CLIENT_ID", "generic")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "legacy")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_CLIENT_ID == "generic"
+
+
+def test_keycloak_fallback_still_works(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "legacy")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_CLIENT_ID == "legacy"
+    assert reloaded.KEYCLOAK_CLIENT_ID == "legacy"  # alias constant still mirrors
+
+
+def test_gundi_oauth_scope_default(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_SCOPE == "openid"
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `uv run pytest tests/client/test_settings.py -v`
+Expected: `test_gundi_oauth_names_work_alone` and `test_gundi_oauth_prefix_wins_over_oauth_and_keycloak` FAIL (the `GUNDI_OAUTH_*` values are ignored, constants come back None/generic). The other three may already pass — that's fine, they pin existing behavior.
+
+- [ ] **Step 3: Implement the lookup chains**
+
+In `gundi_client_v2/settings.py`, replace lines 18–28 (the comment block and the six assignments) with:
+
+```python
+# OAuth settings — GUNDI_OAUTH_* preferred; OAUTH_* and KEYCLOAK_* accepted for
+# backward compatibility. The token URL is either set directly via
+# GUNDI_OAUTH_TOKEN_URL or discovered at runtime from GUNDI_OAUTH_ISSUER via the
+# OIDC discovery document.
+OAUTH_ISSUER = env.str(
+    "GUNDI_OAUTH_ISSUER", env.str("OAUTH_ISSUER", env.str("KEYCLOAK_ISSUER", None))
+)
+OAUTH_TOKEN_URL = env.str("GUNDI_OAUTH_TOKEN_URL", env.str("OAUTH_TOKEN_URL", None))
+OAUTH_CLIENT_ID = env.str(
+    "GUNDI_OAUTH_CLIENT_ID",
+    env.str("OAUTH_CLIENT_ID", env.str("KEYCLOAK_CLIENT_ID", None)),
+)
+OAUTH_CLIENT_SECRET = env.str(
+    "GUNDI_OAUTH_CLIENT_SECRET",
+    env.str("OAUTH_CLIENT_SECRET", env.str("KEYCLOAK_CLIENT_SECRET", None)),
+)
+OAUTH_AUDIENCE = env.str(
+    "GUNDI_OAUTH_AUDIENCE",
+    env.str("OAUTH_AUDIENCE", env.str("KEYCLOAK_AUDIENCE", None)),
+)
+OAUTH_SCOPE = env.str("GUNDI_OAUTH_SCOPE", env.str("OAUTH_SCOPE", "openid"))
+```
+
+Leave everything else in the file untouched (including the `KEYCLOAK_* = OAUTH_*` alias block below it).
+
+- [ ] **Step 4: Run the test file to verify all pass**
+
+Run: `uv run pytest tests/client/test_settings.py -v`
+Expected: ALL PASS (new tests plus the five pre-existing ones).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+uv run black gundi_client_v2/settings.py tests/client/test_settings.py
+git add gundi_client_v2/settings.py tests/client/test_settings.py
+git commit -m "feat: prefer GUNDI_OAUTH_* env vars in settings, keep OAUTH_*/KEYCLOAK_* fallback"
+```
+
+---
+
+### Task 2: CLI env resolution and error messages
+
+**Files:**
+- Modify: `gundi_client_v2/cli/_client.py` (docstrings at 2-7 and 32-46; `_REQUIRED_ENV` at 24-28; `build_client()` at 47-83; `_build_profile_client()` at 183; `build_client_for_login()` at 208-210)
+- Test: `tests/test_cli.py`, `tests/test_cli_auth.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 — the CLI reads `os.environ` directly, not `settings`.
+- Produces: module-private helper `_getenv(name: str) -> Optional[str]` in `gundi_client_v2/cli/_client.py` that returns `os.environ.get(f"GUNDI_{name}") or os.environ.get(name)`. `build_client()`, `_build_profile_client()`, and `build_client_for_login()` keep their existing signatures. Missing-config error text now names `GUNDI_OAUTH_CLIENT_ID`, `GUNDI_OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD)`, and `GUNDI_OAUTH_ISSUER (or GUNDI_OAUTH_TOKEN_URL)`.
+
+- [ ] **Step 1: Update test hygiene helpers so new-name env vars can't leak in**
+
+The new prefix takes precedence, so a developer's real `.env` exporting `GUNDI_OAUTH_*` would silently override fixture values. In `tests/test_cli.py`, extend `_clear_auth_env` (lines 35-49) to:
+
+```python
+def _clear_auth_env(monkeypatch):
+    """Drop every auth env var so each fixture starts from a known-empty state.
+
+    Without this, a developer's real .env (loaded by the client at import) could
+    leak username/password/issuer into a test and change the selected grant.
+    """
+    for var in (
+        "OAUTH_CLIENT_ID",
+        "OAUTH_CLIENT_SECRET",
+        "OAUTH_TOKEN_URL",
+        "OAUTH_ISSUER",
+        "OAUTH_AUDIENCE",
+        "GUNDI_USERNAME",
+        "GUNDI_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(f"GUNDI_{var}", raising=False)
+```
+
+In `tests/test_cli.py::test_missing_env_var_exits_2` (line 335), replace the inline delenv loop with `_clear_auth_env(monkeypatch)` plus `monkeypatch.delenv("GUNDI_API_BASE_URL", raising=False)`. In `test_missing_token_endpoint_exits_2` (line 354), add `_clear_auth_env(monkeypatch)` as the first line (before the setenv calls).
+
+In `tests/test_cli_auth.py`, extend the clear loop at line 18 from `("OAUTH_CLIENT_SECRET", "GUNDI_PASSWORD", "GUNDI_USERNAME")` to `("OAUTH_CLIENT_SECRET", "GUNDI_OAUTH_CLIENT_SECRET", "GUNDI_PASSWORD", "GUNDI_USERNAME")`.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/test_cli.py` (uses the existing `runner`, `BASE_URL`, `TOKEN_URL`, `INTEGRATIONS_URL`, `_mock_auth`, and `_clear_auth_env` helpers):
+
+```python
+@pytest.fixture
+def cli_env_gundi_prefixed(monkeypatch):
+    """Client-credentials configured entirely via the new GUNDI_OAUTH_* names."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("GUNDI_API_BASE_URL", BASE_URL)
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_ID", "confidential-client")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_SECRET", "shhh")
+    monkeypatch.setenv("GUNDI_OAUTH_TOKEN_URL", TOKEN_URL)
+
+
+def test_list_with_gundi_prefixed_env(
+    cli_env_gundi_prefixed, auth_token_response, destination_integration_details
+):
+    with respx.mock(assert_all_called=False) as mock:
+        _mock_auth(mock, auth_token_response)
+        mock.get(INTEGRATIONS_URL).respond(
+            status_code=httpx.codes.OK,
+            json={"results": [destination_integration_details], "next": None},
+        )
+
+        result = runner.invoke(app, ["integrations", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert destination_integration_details["id"] in result.output
+
+
+def test_gundi_prefixed_wins_over_bare_name(
+    cli_env, auth_token_response, destination_integration_details, monkeypatch
+):
+    # cli_env sets the bare OAUTH_* names; the GUNDI_ spelling must win.
+    monkeypatch.setenv("OAUTH_CLIENT_SECRET", "wrong-secret")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_SECRET", "shhh")
+    with respx.mock(assert_all_called=False) as mock:
+        token_route = mock.post(TOKEN_URL).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        mock.get(INTEGRATIONS_URL).respond(
+            status_code=httpx.codes.OK,
+            json={"results": [destination_integration_details], "next": None},
+        )
+
+        result = runner.invoke(app, ["integrations", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert b"client_secret=shhh" in token_route.calls.last.request.content
+
+
+def test_missing_env_error_names_gundi_prefixed_vars(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("GUNDI_API_BASE_URL", raising=False)
+
+    result = runner.invoke(app, ["integrations", "list"])
+
+    assert result.exit_code == 2, result.output
+    assert "GUNDI_OAUTH_CLIENT_ID" in result.output
+    assert "GUNDI_OAUTH_ISSUER (or GUNDI_OAUTH_TOKEN_URL)" in result.output
+    assert (
+        "GUNDI_OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD)"
+        in result.output
+    )
+```
+
+Note: existing message assertions like `assert "OAUTH_ISSUER" in result.output` (lines 351, 365) keep passing unchanged, because `GUNDI_OAUTH_ISSUER` contains the substring `OAUTH_ISSUER`. Do not edit them.
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `uv run pytest tests/test_cli.py -v -k "gundi_prefixed or names_gundi"`
+Expected: all three FAIL — `test_list_with_gundi_prefixed_env` exits 2 (vars not recognized), `test_gundi_prefixed_wins_over_bare_name` authenticates with `wrong-secret`, `test_missing_env_error_names_gundi_prefixed_vars` finds the old un-prefixed names in the message.
+
+- [ ] **Step 4: Implement the CLI changes**
+
+In `gundi_client_v2/cli/_client.py`:
+
+a) Delete the `_REQUIRED_ENV` dict (lines 24-28) and add the helper in its place:
+
+```python
+def _getenv(name: str) -> Optional[str]:
+    """Resolve an OAuth env var, preferring the GUNDI_-prefixed spelling
+    (``GUNDI_OAUTH_X``) over the bare ``OAUTH_X`` kept for backward compatibility."""
+    return os.environ.get(f"GUNDI_{name}") or os.environ.get(name)
+```
+
+b) Replace the body of `build_client()` with (docstring updated to the new names):
+
+```python
+def build_client() -> GundiClient:
+    """Construct a GundiClient from environment variables.
+
+    Mirrors the library's auth rules. A ``client_id`` is always required, plus:
+
+    - **Credentials** — either ``GUNDI_USERNAME`` + ``GUNDI_PASSWORD`` (password
+      grant, public client) or ``GUNDI_OAUTH_CLIENT_SECRET`` (client-credentials,
+      confidential client). When both are present the client uses the password
+      grant.
+    - **Token endpoint** — ``GUNDI_OAUTH_ISSUER`` (preferred; resolved via OIDC
+      discovery, IdP-agnostic) or an explicit ``GUNDI_OAUTH_TOKEN_URL``. When
+      both are set, the explicit URL wins.
+
+    ``GUNDI_OAUTH_AUDIENCE`` is forwarded when set (some IdPs require it). Each
+    ``GUNDI_OAUTH_*`` var also accepts its bare ``OAUTH_*`` spelling for backward
+    compatibility. Exits with code 2, listing what's missing, when required
+    configuration is absent.
+    """
+    kwargs = {}
+    missing = []
+    if base_url := os.environ.get("GUNDI_API_BASE_URL"):
+        kwargs["base_url"] = base_url
+    else:
+        missing.append("GUNDI_API_BASE_URL")
+    if client_id := _getenv("OAUTH_CLIENT_ID"):
+        kwargs["oauth_client_id"] = client_id
+    else:
+        missing.append("GUNDI_OAUTH_CLIENT_ID")
+
+    # Credentials: password grant (username + password) or client-credentials
+    # (client_secret). At least one full set is required.
+    username = os.environ.get("GUNDI_USERNAME")
+    password = os.environ.get("GUNDI_PASSWORD")
+    client_secret = _getenv("OAUTH_CLIENT_SECRET")
+    if username:
+        kwargs["username"] = username
+    if password:
+        kwargs["password"] = password
+    if client_secret:
+        kwargs["oauth_client_secret"] = client_secret
+    if not (username and password) and not client_secret:
+        missing.append("GUNDI_OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD)")
+
+    # Token endpoint: discovery via GUNDI_OAUTH_ISSUER preferred,
+    # GUNDI_OAUTH_TOKEN_URL is the explicit fallback. The client prefers
+    # oauth_token_url when both exist.
+    if issuer := _getenv("OAUTH_ISSUER"):
+        kwargs["oauth_issuer"] = issuer
+    if token_url := _getenv("OAUTH_TOKEN_URL"):
+        kwargs["oauth_token_url"] = token_url
+    if not issuer and not token_url:
+        missing.append("GUNDI_OAUTH_ISSUER (or GUNDI_OAUTH_TOKEN_URL)")
+
+    if missing:
+        typer.echo(f"Error: missing required env vars: {', '.join(missing)}", err=True)
+        raise typer.Exit(2)
+    if audience := _getenv("OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = audience
+    return GundiClient(**kwargs)
+```
+
+c) In `_build_profile_client()` (line 183), change `os.environ.get("OAUTH_CLIENT_SECRET")` to `_getenv("OAUTH_CLIENT_SECRET")`.
+
+d) In `build_client_for_login()` (lines 208-210), change `os.environ.get("OAUTH_CLIENT_SECRET")` to `_getenv("OAUTH_CLIENT_SECRET")`.
+
+e) In the module docstring (lines 1-7), no env var names appear — leave it.
+
+- [ ] **Step 5: Run the CLI test files to verify all pass**
+
+Run: `uv run pytest tests/test_cli.py tests/test_cli_auth.py -v`
+Expected: ALL PASS — new tests plus every pre-existing old-name test.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+uv run black gundi_client_v2/cli/_client.py tests/test_cli.py tests/test_cli_auth.py
+git add gundi_client_v2/cli/_client.py tests/test_cli.py tests/test_cli_auth.py
+git commit -m "feat(cli): prefer GUNDI_OAUTH_* env vars, name them in error messages"
+```
+
+---
+
+### Task 3: Docs, examples, and docstrings sweep
+
+**Files:**
+- Modify: `README.md`, `MIGRATION.md`, `docs/troubleshooting.md`, `docs/getting-started/auth-setup.md`, `docs/getting-started/first-request.md`, `docs/authentication/overview.md`, `docs/authentication/password-grant.md`, `docs/authentication/client-credentials.md`, `docs/authentication/oidc-discovery.md`, `docs/authentication/refresh-and-errors.md`, `examples/README.md`, `examples/list_connections_password_grant.py`, `examples/list_connections_discovery.py`, `examples/list_connections_client_credentials.py`, `examples/send_observations.py`, `.claude/skills/using-the-gundi-cli/SKILL.md`, `gundi_client_v2/client.py:279-300` (docstring only)
+
+**Interfaces:**
+- Consumes: the behavior shipped by Tasks 1–2 (new names actually work).
+- Produces: nothing programmatic — documentation only. No code behavior may change in this task; `gundi_client_v2/client.py` edits are docstring text only.
+
+- [ ] **Step 1: Enumerate every real occurrence**
+
+Run: `grep -rn "OAUTH_\|KEYCLOAK_" README.md MIGRATION.md docs examples .claude gundi_client_v2/client.py --include="*.md" --include="*.py" | grep -v "docs/superpowers" | grep -v "GUNDI_OAUTH"`
+
+This is the authoritative worklist (the spec's file list above is the expected result). Skip `site/` (generated) and `docs/superpowers/` (historical records).
+
+- [ ] **Step 2: Update the library docstring**
+
+In `gundi_client_v2/client.py` lines 279-300, rewrite the env-var references in the `GundiClient` docstring so each parameter names the new form first, e.g.:
+
+- `Env: ``GUNDI_OAUTH_CLIENT_ID`` / ``OAUTH_CLIENT_ID`` / ``KEYCLOAK_CLIENT_ID``.`
+- `Env: ``GUNDI_OAUTH_CLIENT_SECRET`` / ``OAUTH_CLIENT_SECRET`` / ``KEYCLOAK_CLIENT_SECRET``.`
+- `Env: ``GUNDI_OAUTH_TOKEN_URL`` / ``OAUTH_TOKEN_URL``.`
+- `Env: ``GUNDI_OAUTH_ISSUER`` / ``OAUTH_ISSUER`` / ``KEYCLOAK_ISSUER``.`
+- `Env: ``GUNDI_OAUTH_AUDIENCE`` / ``OAUTH_AUDIENCE`` / ``KEYCLOAK_AUDIENCE``.`
+- `Env: ``GUNDI_OAUTH_SCOPE`` / ``OAUTH_SCOPE`` (default ``"openid"``).`
+
+- [ ] **Step 3: Update docs, examples, and the CLI skill**
+
+For every hit from Step 1 in `README.md`, `docs/`, `examples/`, and `.claude/skills/using-the-gundi-cli/SKILL.md`: replace `OAUTH_X` with `GUNDI_OAUTH_X` as the primary documented name. Where a page first introduces the env vars (README auth section, `docs/getting-started/auth-setup.md`, `docs/authentication/overview.md`, `examples/README.md`, the SKILL.md), add one sentence:
+
+> The un-prefixed `OAUTH_*` names (and, for the library, the legacy `KEYCLOAK_*` names) are still accepted as fallbacks.
+
+In `MIGRATION.md`, leave the existing 2.x → 3.0 history intact and add a short section at the top:
+
+```markdown
+## 3.7.0 — `GUNDI_OAUTH_*` env var names
+
+The preferred env var names for OAuth configuration are now prefixed with
+`GUNDI_` to avoid collisions with other tools sharing an environment:
+
+| Old (still accepted) | New (preferred) |
+|---|---|
+| `OAUTH_ISSUER` | `GUNDI_OAUTH_ISSUER` |
+| `OAUTH_TOKEN_URL` | `GUNDI_OAUTH_TOKEN_URL` |
+| `OAUTH_CLIENT_ID` | `GUNDI_OAUTH_CLIENT_ID` |
+| `OAUTH_CLIENT_SECRET` | `GUNDI_OAUTH_CLIENT_SECRET` |
+| `OAUTH_AUDIENCE` | `GUNDI_OAUTH_AUDIENCE` |
+| `OAUTH_SCOPE` | `GUNDI_OAUTH_SCOPE` |
+
+No action is required: the old `OAUTH_*` names (and the pre-3.0 `KEYCLOAK_*`
+names, for the library) keep working as silent fallbacks. When both spellings
+are set, the `GUNDI_`-prefixed one wins.
+```
+
+Keep example `.env` snippets and shell exports runnable — they should show only the new names.
+
+- [ ] **Step 4: Verify nothing was missed and nothing broke**
+
+Run: `grep -rn "OAUTH_\|KEYCLOAK_" README.md MIGRATION.md docs examples .claude --include="*.md" --include="*.py" | grep -v "docs/superpowers" | grep -v "GUNDI_OAUTH" | grep -v "still accepted" | grep -v "fallback"`
+Expected: no hits other than intentional back-compat mentions (eyeball the remainder).
+
+Run: `uv run pytest`
+Expected: full suite PASSES (examples aren't imported by tests, but this catches accidental code edits).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+uv run black examples gundi_client_v2/client.py
+git add README.md MIGRATION.md docs examples .claude/skills gundi_client_v2/client.py
+git commit -m "docs: document GUNDI_OAUTH_* as the preferred env var names"
+```
+
+---
+
+### Task 4: Version bump and full verification
+
+**Files:**
+- Modify: `gundi_client_v2/__init__.py:1`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `__version__ = "3.7.0"` (hatch reads the version from this file per `pyproject.toml [tool.hatch.version]`).
+
+- [ ] **Step 1: Bump the version**
+
+In `gundi_client_v2/__init__.py` line 1, change `__version__ = "3.6.3"` to `__version__ = "3.7.0"`.
+
+- [ ] **Step 2: Run the full test suite and style check**
+
+Run: `uv run pytest && uv run black --check .`
+Expected: ALL PASS, no reformatting needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gundi_client_v2/__init__.py
+git commit -m "Bump version to 3.7.0"
+```

--- a/docs/superpowers/specs/2026-07-30-gundi-oauth-env-prefix-design.md
+++ b/docs/superpowers/specs/2026-07-30-gundi-oauth-env-prefix-design.md
@@ -1,0 +1,102 @@
+# GUNDI_OAUTH_* env var prefix — design
+
+**Date:** 2026-07-30
+**Status:** Approved
+**Target release:** 3.7.0 (minor; no breaking change)
+
+## Problem
+
+The 3.0 rename of `KEYCLOAK_*` to `OAUTH_*` made the auth env vars generic but
+left them unqualified. Generic names like `OAUTH_CLIENT_ID` risk collisions with
+other tools sharing an environment, and are inconsistent with the vars that
+already carry the project prefix (`GUNDI_API_BASE_URL`, `GUNDI_USERNAME`,
+`GUNDI_PASSWORD`, `GUNDI_CLIENT_ENVFILE`). The `OAUTH_*` names have shipped in
+every 3.x release, so they cannot simply be dropped.
+
+## Decision
+
+The documented, preferred env var names become:
+
+- `GUNDI_OAUTH_ISSUER`
+- `GUNDI_OAUTH_TOKEN_URL`
+- `GUNDI_OAUTH_CLIENT_ID`
+- `GUNDI_OAUTH_CLIENT_SECRET`
+- `GUNDI_OAUTH_AUDIENCE`
+- `GUNDI_OAUTH_SCOPE`
+
+Old names keep working via **silent fallback** — no deprecation warnings, no
+removal planned. Docs and examples switch to the new names.
+
+## Scope
+
+OAuth vars only. `LOG_LEVEL` and `SENSORS_API_BASE_URL` stay unprefixed
+(explicitly out of scope per user decision). No deprecation warnings. The CLI's
+named-environments config file stores generic keys (`client_id`, `issuer`, …),
+not env var names, and is unaffected.
+
+## Changes
+
+### 1. `gundi_client_v2/settings.py`
+
+Extend each env lookup chain by one link at the front:
+
+| Setting | Lookup chain |
+|---|---|
+| `OAUTH_ISSUER` | `GUNDI_OAUTH_ISSUER` → `OAUTH_ISSUER` → `KEYCLOAK_ISSUER` |
+| `OAUTH_TOKEN_URL` | `GUNDI_OAUTH_TOKEN_URL` → `OAUTH_TOKEN_URL` |
+| `OAUTH_CLIENT_ID` | `GUNDI_OAUTH_CLIENT_ID` → `OAUTH_CLIENT_ID` → `KEYCLOAK_CLIENT_ID` |
+| `OAUTH_CLIENT_SECRET` | `GUNDI_OAUTH_CLIENT_SECRET` → `OAUTH_CLIENT_SECRET` → `KEYCLOAK_CLIENT_SECRET` |
+| `OAUTH_AUDIENCE` | `GUNDI_OAUTH_AUDIENCE` → `OAUTH_AUDIENCE` → `KEYCLOAK_AUDIENCE` |
+| `OAUTH_SCOPE` | `GUNDI_OAUTH_SCOPE` → `OAUTH_SCOPE` → `"openid"` |
+
+`TOKEN_URL` and `SCOPE` have no `KEYCLOAK_*` ancestor. The module constants stay
+named `OAUTH_*` (plus the existing `KEYCLOAK_*` aliases): the rename concerns
+the environment interface, not the Python attribute names, and renaming the
+constants would churn `client.py` and the CLI with no user-visible benefit.
+
+### 2. CLI — `gundi_client_v2/cli/_client.py`
+
+Add a small helper that resolves an OAuth var with the prefix preferred:
+`_getenv("OAUTH_CLIENT_ID")` checks `GUNDI_OAUTH_CLIENT_ID` first, then
+`OAUTH_CLIENT_ID`. Use it at every `os.environ.get("OAUTH_*")` call site
+(seven sites: `_REQUIRED_ENV` handling in `build_client()`, the client-secret
+reads in `build_client()`, `_build_profile_client()`, and
+`build_client_for_login()`, plus issuer/token-url/audience in
+`build_client()`).
+
+The CLI chain is `GUNDI_OAUTH_*` → `OAUTH_*` only — the CLI postdates the
+Keycloak rename and never accepted `KEYCLOAK_*`; that stays true.
+
+Missing-config error messages name the new preferred form, e.g.
+`GUNDI_OAUTH_CLIENT_ID` and
+`GUNDI_OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD)`.
+
+### 3. Docs, examples, docstrings
+
+Switch primary names to `GUNDI_OAUTH_*` with a one-line note that `OAUTH_*`
+(and `KEYCLOAK_*` for the library) remain accepted:
+
+- `README.md`, `MIGRATION.md`, `docs/` (getting-started, authentication,
+  troubleshooting)
+- `examples/*.py` and `examples/README.md`
+- Docstrings in `gundi_client_v2/client.py` and `gundi_client_v2/cli/_client.py`
+- `.claude/skills/using-the-gundi-cli/SKILL.md`
+
+### 4. Tests
+
+- `tests/client/test_settings.py`: precedence tests — `GUNDI_OAUTH_X` wins over
+  `OAUTH_X`, which wins over `KEYCLOAK_X`; new names work alone.
+- `tests/test_cli.py` / `tests/test_cli_auth.py`: CLI accepts `GUNDI_OAUTH_*`;
+  missing-var error messages show the new names.
+- Existing old-name tests stay untouched — they are the back-compat regression
+  suite.
+
+## Error handling
+
+No new failure modes: a var missing from every link of its chain behaves
+exactly as a missing var does today (library: `None` / auth error at request
+time; CLI: exit 2 listing missing names).
+
+## Release
+
+Version bump to 3.7.0 following the existing release process.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ for the full catalog with explanations.
 
 ## `httpx.ConnectError: [Errno -2] Name or service not known`
 
-The hostname in `GUNDI_API_BASE_URL` or `OAUTH_ISSUER` doesn't resolve.
+The hostname in `GUNDI_API_BASE_URL` or `GUNDI_OAUTH_ISSUER` doesn't resolve.
 
 **Fix:** Verify the URLs are correct and reachable from the host running
 your code. Common gotchas:

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -4,27 +4,31 @@
 #
 #   send_observations.py                       — password grant + sender
 #       GUNDI_USERNAME, GUNDI_PASSWORD,
-#       OAUTH_CLIENT_ID, OAUTH_TOKEN_URL (or OAUTH_ISSUER),
+#       GUNDI_OAUTH_CLIENT_ID, GUNDI_OAUTH_TOKEN_URL (or GUNDI_OAUTH_ISSUER),
 #       GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
 #       GUNDI_INTEGRATION_NAME
 #
 #   list_connections_client_credentials.py     — client_credentials grant
-#       OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_TOKEN_URL,
+#       GUNDI_OAUTH_CLIENT_ID, GUNDI_OAUTH_CLIENT_SECRET, GUNDI_OAUTH_TOKEN_URL,
 #       GUNDI_API_BASE_URL
 #
 #   list_connections_password_grant.py         — password grant
 #       GUNDI_USERNAME, GUNDI_PASSWORD,
-#       OAUTH_CLIENT_ID, OAUTH_TOKEN_URL,
+#       GUNDI_OAUTH_CLIENT_ID, GUNDI_OAUTH_TOKEN_URL,
 #       GUNDI_API_BASE_URL
 #
 #   list_connections_discovery.py              — password grant + OIDC discovery
 #       GUNDI_USERNAME, GUNDI_PASSWORD,
-#       OAUTH_CLIENT_ID, OAUTH_ISSUER,
+#       GUNDI_OAUTH_CLIENT_ID, GUNDI_OAUTH_ISSUER,
 #       GUNDI_API_BASE_URL
 #       (requires gundi-client-v2 >= 3.0.0)
 #
-# OAUTH_AUDIENCE is conditional for ALL examples: required by some IdPs
+# GUNDI_OAUTH_AUDIENCE is conditional for ALL examples: required by some IdPs
 # (e.g. Auth0), ignored by Keycloak password grant.
+#
+# The un-prefixed OAUTH_* names (and, for the library, the legacy KEYCLOAK_*
+# names) are still accepted as fallbacks — this file just shows the preferred
+# GUNDI_OAUTH_* names.
 
 # User credentials (password-grant examples + send_observations.py)
 GUNDI_USERNAME=your-username
@@ -34,22 +38,22 @@ GUNDI_PASSWORD=your-password
 GUNDI_INTEGRATION_NAME="Your Integration Name"
 
 # OAuth client config (all examples)
-OAUTH_CLIENT_ID=your-oauth-client-id
+GUNDI_OAUTH_CLIENT_ID=your-oauth-client-id
 # Required only by list_connections_client_credentials.py
-OAUTH_CLIENT_SECRET=your-oauth-client-secret
+GUNDI_OAUTH_CLIENT_SECRET=your-oauth-client-secret
 # Required by some IdPs (e.g., Auth0 won't issue a usable API access token
 # without it); ignored by others (Keycloak password grant). Set if needed.
-OAUTH_AUDIENCE=your-oauth-audience
+GUNDI_OAUTH_AUDIENCE=your-oauth-audience
 
 # Token endpoint — configure ONE of these:
-#   - OAUTH_ISSUER:    the library will discover the token endpoint via
-#                      {OAUTH_ISSUER}/.well-known/openid-configuration
+#   - GUNDI_OAUTH_ISSUER:    the library will discover the token endpoint via
+#                      {GUNDI_OAUTH_ISSUER}/.well-known/openid-configuration
 #                      (used by list_connections_discovery.py;
 #                       requires gundi-client-v2 >= 3.0.0)
-#   - OAUTH_TOKEN_URL: the explicit token endpoint URL
+#   - GUNDI_OAUTH_TOKEN_URL: the explicit token endpoint URL
 #                      (used by the other examples)
-OAUTH_ISSUER=https://auth.example.com/realms/your-realm
-#OAUTH_TOKEN_URL=https://auth.example.com/realms/your-realm/protocol/openid-connect/token
+GUNDI_OAUTH_ISSUER=https://auth.example.com/realms/your-realm
+#GUNDI_OAUTH_TOKEN_URL=https://auth.example.com/realms/your-realm/protocol/openid-connect/token
 
 # API base URLs (required for the examples to function)
 GUNDI_API_BASE_URL=https://api.example.com

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,16 +28,18 @@ Demonstrates:
 - `GUNDI_USERNAME` – your Gundi username
 - `GUNDI_PASSWORD` – your Gundi password
 - `GUNDI_INTEGRATION_NAME` – exact name of the integration to use for sending (e.g. the display name in the portal)
-- `OAUTH_CLIENT_ID` – OAuth client ID for the password grant
+- `GUNDI_OAUTH_CLIENT_ID` – OAuth client ID for the password grant
 - `GUNDI_API_BASE_URL` – Gundi API base URL (portal/configuration API)
 - `SENSORS_API_BASE_URL` – Sensors/ingestion API base URL (used by `GundiDataSenderClient`)
 - At least one of:
-  - `OAUTH_ISSUER` – OIDC issuer base URL (e.g. `https://auth.example.com/realms/my-realm`); the token endpoint is discovered automatically via `{OAUTH_ISSUER}/.well-known/openid-configuration`.
-  - `OAUTH_TOKEN_URL` – explicit OAuth token endpoint URL (overrides OIDC discovery when set).
+  - `GUNDI_OAUTH_ISSUER` – OIDC issuer base URL (e.g. `https://auth.example.com/realms/my-realm`); the token endpoint is discovered automatically via `{GUNDI_OAUTH_ISSUER}/.well-known/openid-configuration`.
+  - `GUNDI_OAUTH_TOKEN_URL` – explicit OAuth token endpoint URL (overrides OIDC discovery when set).
 
 **Conditional:**
 
-- `OAUTH_AUDIENCE` – OAuth audience. Required by some IdPs (e.g., Auth0 needs it to issue a usable API access token); ignored by others (Keycloak password grant). Set if your IdP requires it.
+- `GUNDI_OAUTH_AUDIENCE` – OAuth audience. Required by some IdPs (e.g., Auth0 needs it to issue a usable API access token); ignored by others (Keycloak password grant). Set if your IdP requires it.
+
+The un-prefixed `OAUTH_*` names (and, for the library, the legacy `KEYCLOAK_*` names) are still accepted as fallbacks.
 
 **Optional:**
 
@@ -76,9 +78,9 @@ in all three — the variation is purely how the client is configured.
 
 | Script | Auth path | Token URL source |
 |---|---|---|
-| `list_connections_client_credentials.py` | client_credentials grant (confidential client / M2M) | explicit `OAUTH_TOKEN_URL` |
-| `list_connections_password_grant.py` | password grant (public client / user-facing) | explicit `OAUTH_TOKEN_URL` |
-| `list_connections_discovery.py` | password grant + OIDC discovery (IdP-agnostic) | discovered from `OAUTH_ISSUER` — requires `gundi-client-v2 >= 3.0.0` |
+| `list_connections_client_credentials.py` | client_credentials grant (confidential client / M2M) | explicit `GUNDI_OAUTH_TOKEN_URL` |
+| `list_connections_password_grant.py` | password grant (public client / user-facing) | explicit `GUNDI_OAUTH_TOKEN_URL` |
+| `list_connections_discovery.py` | password grant + OIDC discovery (IdP-agnostic) | discovered from `GUNDI_OAUTH_ISSUER` — requires `gundi-client-v2 >= 3.0.0` |
 
 All three run the same way as `send_observations.py`:
 

--- a/examples/list_connections_client_credentials.py
+++ b/examples/list_connections_client_credentials.py
@@ -3,9 +3,10 @@ Example: list Gundi connections using the OAuth2 client_credentials grant
 (confidential client / service-to-service auth).
 
 # Required env vars:
-#   GUNDI_API_BASE_URL, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_TOKEN_URL
+#   GUNDI_API_BASE_URL, GUNDI_OAUTH_CLIENT_ID, GUNDI_OAUTH_CLIENT_SECRET,
+#   GUNDI_OAUTH_TOKEN_URL
 # Conditional:
-#   OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
+#   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
 #                     API access token without it); ignored by Keycloak.
 
 Run from the examples/ directory (so the local .env is loaded):
@@ -31,23 +32,23 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_API_BASE_URL")
 
-    if client_id := os.environ.get("OAUTH_CLIENT_ID"):
+    if client_id := os.environ.get("GUNDI_OAUTH_CLIENT_ID"):
         kwargs["oauth_client_id"] = client_id
     else:
-        missing.append("OAUTH_CLIENT_ID")
+        missing.append("GUNDI_OAUTH_CLIENT_ID")
 
-    if client_secret := os.environ.get("OAUTH_CLIENT_SECRET"):
+    if client_secret := os.environ.get("GUNDI_OAUTH_CLIENT_SECRET"):
         kwargs["oauth_client_secret"] = client_secret
     else:
-        missing.append("OAUTH_CLIENT_SECRET")
+        missing.append("GUNDI_OAUTH_CLIENT_SECRET")
 
-    if token_url := os.environ.get("OAUTH_TOKEN_URL"):
+    if token_url := os.environ.get("GUNDI_OAUTH_TOKEN_URL"):
         kwargs["oauth_token_url"] = token_url
     else:
-        missing.append("OAUTH_TOKEN_URL")
+        missing.append("GUNDI_OAUTH_TOKEN_URL")
 
     # Conditional — sent to the token endpoint when set; some IdPs require it.
-    if audience := os.environ.get("OAUTH_AUDIENCE"):
+    if audience := os.environ.get("GUNDI_OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = audience
 
     if missing:

--- a/examples/list_connections_client_credentials.py
+++ b/examples/list_connections_client_credentials.py
@@ -8,6 +8,7 @@ Example: list Gundi connections using the OAuth2 client_credentials grant
 # Conditional:
 #   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
 #                     API access token without it); ignored by Keycloak.
+# Legacy un-prefixed OAUTH_* spellings are also accepted (prefixed wins).
 
 Run from the examples/ directory (so the local .env is loaded):
 
@@ -22,6 +23,11 @@ import os
 from gundi_client_v2 import GundiClient
 
 
+def _env(name: str):
+    """Prefer the GUNDI_-prefixed spelling; fall back to the legacy bare name."""
+    return os.environ.get(f"GUNDI_{name}") or os.environ.get(name)
+
+
 def _get_kwargs() -> dict:
     """Validate required env vars; raise ValueError listing any that are missing."""
     missing = []
@@ -32,23 +38,23 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_API_BASE_URL")
 
-    if client_id := os.environ.get("GUNDI_OAUTH_CLIENT_ID"):
+    if client_id := _env("OAUTH_CLIENT_ID"):
         kwargs["oauth_client_id"] = client_id
     else:
         missing.append("GUNDI_OAUTH_CLIENT_ID")
 
-    if client_secret := os.environ.get("GUNDI_OAUTH_CLIENT_SECRET"):
+    if client_secret := _env("OAUTH_CLIENT_SECRET"):
         kwargs["oauth_client_secret"] = client_secret
     else:
         missing.append("GUNDI_OAUTH_CLIENT_SECRET")
 
-    if token_url := os.environ.get("GUNDI_OAUTH_TOKEN_URL"):
+    if token_url := _env("OAUTH_TOKEN_URL"):
         kwargs["oauth_token_url"] = token_url
     else:
         missing.append("GUNDI_OAUTH_TOKEN_URL")
 
     # Conditional — sent to the token endpoint when set; some IdPs require it.
-    if audience := os.environ.get("GUNDI_OAUTH_AUDIENCE"):
+    if audience := _env("OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = audience
 
     if missing:

--- a/examples/list_connections_discovery.py
+++ b/examples/list_connections_discovery.py
@@ -1,20 +1,20 @@
 """
 Example: list Gundi connections using the OAuth2 password grant with OIDC
 discovery — the library finds the token endpoint at
-{OAUTH_ISSUER}/.well-known/openid-configuration instead of needing
-OAUTH_TOKEN_URL configured explicitly.
+{GUNDI_OAUTH_ISSUER}/.well-known/openid-configuration instead of needing
+GUNDI_OAUTH_TOKEN_URL configured explicitly.
 
 This is the IdP-agnostic path: it works against Keycloak, Auth0, Okta, and
-any other OIDC-compliant IdP with no code change — only OAUTH_ISSUER
-differs per deployment. After the Auth0 migration, point OAUTH_ISSUER at
+any other OIDC-compliant IdP with no code change — only GUNDI_OAUTH_ISSUER
+differs per deployment. After the Auth0 migration, point GUNDI_OAUTH_ISSUER at
 the Auth0 tenant and this same script keeps working.
 
 # Required env vars:
-#   GUNDI_API_BASE_URL, OAUTH_CLIENT_ID,
+#   GUNDI_API_BASE_URL, GUNDI_OAUTH_CLIENT_ID,
 #   GUNDI_USERNAME, GUNDI_PASSWORD,
-#   OAUTH_ISSUER
+#   GUNDI_OAUTH_ISSUER
 # Conditional:
-#   OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
+#   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
 #                     API access token without it); ignored by Keycloak.
 
 # Requires gundi-client-v2 >= 3.0.0 (OIDC discovery support).
@@ -46,10 +46,10 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_API_BASE_URL")
 
-    if client_id := os.environ.get("OAUTH_CLIENT_ID"):
+    if client_id := os.environ.get("GUNDI_OAUTH_CLIENT_ID"):
         kwargs["oauth_client_id"] = client_id
     else:
-        missing.append("OAUTH_CLIENT_ID")
+        missing.append("GUNDI_OAUTH_CLIENT_ID")
 
     if username := os.environ.get("GUNDI_USERNAME"):
         kwargs["username"] = username
@@ -63,13 +63,13 @@ def _get_kwargs() -> dict:
 
     # NOTE: oauth_issuer (NOT oauth_token_url) — the library will resolve the
     # token endpoint via OIDC discovery at runtime.
-    if issuer := os.environ.get("OAUTH_ISSUER"):
+    if issuer := os.environ.get("GUNDI_OAUTH_ISSUER"):
         kwargs["oauth_issuer"] = issuer
     else:
-        missing.append("OAUTH_ISSUER")
+        missing.append("GUNDI_OAUTH_ISSUER")
 
     # Conditional — sent to the token endpoint when set; some IdPs require it.
-    if audience := os.environ.get("OAUTH_AUDIENCE"):
+    if audience := os.environ.get("GUNDI_OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = audience
 
     if missing:

--- a/examples/list_connections_discovery.py
+++ b/examples/list_connections_discovery.py
@@ -16,6 +16,7 @@ the Auth0 tenant and this same script keeps working.
 # Conditional:
 #   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
 #                     API access token without it); ignored by Keycloak.
+# Legacy un-prefixed OAUTH_* spellings are also accepted (prefixed wins).
 
 # Requires gundi-client-v2 >= 3.0.0 (OIDC discovery support).
 
@@ -36,6 +37,11 @@ import os
 from gundi_client_v2 import GundiClient
 
 
+def _env(name: str):
+    """Prefer the GUNDI_-prefixed spelling; fall back to the legacy bare name."""
+    return os.environ.get(f"GUNDI_{name}") or os.environ.get(name)
+
+
 def _get_kwargs() -> dict:
     """Validate required env vars; raise ValueError listing any that are missing."""
     missing = []
@@ -46,7 +52,7 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_API_BASE_URL")
 
-    if client_id := os.environ.get("GUNDI_OAUTH_CLIENT_ID"):
+    if client_id := _env("OAUTH_CLIENT_ID"):
         kwargs["oauth_client_id"] = client_id
     else:
         missing.append("GUNDI_OAUTH_CLIENT_ID")
@@ -63,13 +69,13 @@ def _get_kwargs() -> dict:
 
     # NOTE: oauth_issuer (NOT oauth_token_url) — the library will resolve the
     # token endpoint via OIDC discovery at runtime.
-    if issuer := os.environ.get("GUNDI_OAUTH_ISSUER"):
+    if issuer := _env("OAUTH_ISSUER"):
         kwargs["oauth_issuer"] = issuer
     else:
         missing.append("GUNDI_OAUTH_ISSUER")
 
     # Conditional — sent to the token endpoint when set; some IdPs require it.
-    if audience := os.environ.get("GUNDI_OAUTH_AUDIENCE"):
+    if audience := _env("OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = audience
 
     if missing:

--- a/examples/list_connections_password_grant.py
+++ b/examples/list_connections_password_grant.py
@@ -9,6 +9,7 @@ Example: list Gundi connections using the OAuth2 password grant
 # Conditional:
 #   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
 #                     API access token without it); ignored by Keycloak.
+# Legacy un-prefixed OAUTH_* spellings are also accepted (prefixed wins).
 
 Run from the examples/ directory (so the local .env is loaded):
 
@@ -23,6 +24,11 @@ import os
 from gundi_client_v2 import GundiClient
 
 
+def _env(name: str):
+    """Prefer the GUNDI_-prefixed spelling; fall back to the legacy bare name."""
+    return os.environ.get(f"GUNDI_{name}") or os.environ.get(name)
+
+
 def _get_kwargs() -> dict:
     """Validate required env vars; raise ValueError listing any that are missing."""
     missing = []
@@ -33,7 +39,7 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_API_BASE_URL")
 
-    if client_id := os.environ.get("GUNDI_OAUTH_CLIENT_ID"):
+    if client_id := _env("OAUTH_CLIENT_ID"):
         kwargs["oauth_client_id"] = client_id
     else:
         missing.append("GUNDI_OAUTH_CLIENT_ID")
@@ -48,13 +54,13 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_PASSWORD")
 
-    if token_url := os.environ.get("GUNDI_OAUTH_TOKEN_URL"):
+    if token_url := _env("OAUTH_TOKEN_URL"):
         kwargs["oauth_token_url"] = token_url
     else:
         missing.append("GUNDI_OAUTH_TOKEN_URL")
 
     # Conditional — sent to the token endpoint when set; some IdPs require it.
-    if audience := os.environ.get("GUNDI_OAUTH_AUDIENCE"):
+    if audience := _env("OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = audience
 
     if missing:

--- a/examples/list_connections_password_grant.py
+++ b/examples/list_connections_password_grant.py
@@ -3,11 +3,11 @@ Example: list Gundi connections using the OAuth2 password grant
 (public client / user-facing developer auth).
 
 # Required env vars:
-#   GUNDI_API_BASE_URL, OAUTH_CLIENT_ID,
+#   GUNDI_API_BASE_URL, GUNDI_OAUTH_CLIENT_ID,
 #   GUNDI_USERNAME, GUNDI_PASSWORD,
-#   OAUTH_TOKEN_URL
+#   GUNDI_OAUTH_TOKEN_URL
 # Conditional:
-#   OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
+#   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g. Auth0 won't issue a usable
 #                     API access token without it); ignored by Keycloak.
 
 Run from the examples/ directory (so the local .env is loaded):
@@ -33,10 +33,10 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_API_BASE_URL")
 
-    if client_id := os.environ.get("OAUTH_CLIENT_ID"):
+    if client_id := os.environ.get("GUNDI_OAUTH_CLIENT_ID"):
         kwargs["oauth_client_id"] = client_id
     else:
-        missing.append("OAUTH_CLIENT_ID")
+        missing.append("GUNDI_OAUTH_CLIENT_ID")
 
     if username := os.environ.get("GUNDI_USERNAME"):
         kwargs["username"] = username
@@ -48,13 +48,13 @@ def _get_kwargs() -> dict:
     else:
         missing.append("GUNDI_PASSWORD")
 
-    if token_url := os.environ.get("OAUTH_TOKEN_URL"):
+    if token_url := os.environ.get("GUNDI_OAUTH_TOKEN_URL"):
         kwargs["oauth_token_url"] = token_url
     else:
-        missing.append("OAUTH_TOKEN_URL")
+        missing.append("GUNDI_OAUTH_TOKEN_URL")
 
     # Conditional — sent to the token endpoint when set; some IdPs require it.
-    if audience := os.environ.get("OAUTH_AUDIENCE"):
+    if audience := os.environ.get("GUNDI_OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = audience
 
     if missing:

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -7,11 +7,11 @@ Set credentials via environment variables (recommended) or pass them in code.
 # Required:
 #   GUNDI_USERNAME, GUNDI_PASSWORD,
 #   GUNDI_API_BASE_URL, SENSORS_API_BASE_URL,
-#   OAUTH_CLIENT_ID,
-#   one of OAUTH_ISSUER (library discovers the token endpoint via OIDC discovery)
-#   or OAUTH_TOKEN_URL (used as-is when set).
+#   GUNDI_OAUTH_CLIENT_ID,
+#   one of GUNDI_OAUTH_ISSUER (library discovers the token endpoint via OIDC
+#   discovery) or GUNDI_OAUTH_TOKEN_URL (used as-is when set).
 # Conditional:
-#   OAUTH_AUDIENCE  — required by some IdPs (e.g., Auth0 won't issue a usable
+#   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g., Auth0 won't issue a usable
 #                     API access token without it); ignored by others (Keycloak
 #                     password grant). Set it if your IdP requires it.
 # Optional:
@@ -43,16 +43,16 @@ def get_client_kwargs():
             "Set GUNDI_USERNAME and GUNDI_PASSWORD in the environment, or pass them in code."
         )
 
-    oauth_client_id = os.environ.get("OAUTH_CLIENT_ID")
-    oauth_token_url = os.environ.get("OAUTH_TOKEN_URL")
-    oauth_issuer = os.environ.get("OAUTH_ISSUER")
+    oauth_client_id = os.environ.get("GUNDI_OAUTH_CLIENT_ID")
+    oauth_token_url = os.environ.get("GUNDI_OAUTH_TOKEN_URL")
+    oauth_issuer = os.environ.get("GUNDI_OAUTH_ISSUER")
     gundi_api_base_url = os.environ.get("GUNDI_API_BASE_URL")
 
     missing = []
     if not oauth_client_id:
-        missing.append("OAUTH_CLIENT_ID")
+        missing.append("GUNDI_OAUTH_CLIENT_ID")
     if not oauth_token_url and not oauth_issuer:
-        missing.append("OAUTH_TOKEN_URL (or OAUTH_ISSUER)")
+        missing.append("GUNDI_OAUTH_TOKEN_URL (or GUNDI_OAUTH_ISSUER)")
     if not gundi_api_base_url:
         missing.append("GUNDI_API_BASE_URL")
     if missing:
@@ -69,8 +69,8 @@ def get_client_kwargs():
         kwargs["oauth_issuer"] = oauth_issuer
     kwargs["oauth_client_id"] = oauth_client_id
     kwargs["base_url"] = gundi_api_base_url
-    if os.environ.get("OAUTH_AUDIENCE"):
-        kwargs["oauth_audience"] = os.environ["OAUTH_AUDIENCE"]
+    if os.environ.get("GUNDI_OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = os.environ["GUNDI_OAUTH_AUDIENCE"]
     return kwargs
 
 

--- a/examples/send_observations.py
+++ b/examples/send_observations.py
@@ -14,6 +14,7 @@ Set credentials via environment variables (recommended) or pass them in code.
 #   GUNDI_OAUTH_AUDIENCE  — required by some IdPs (e.g., Auth0 won't issue a usable
 #                     API access token without it); ignored by others (Keycloak
 #                     password grant). Set it if your IdP requires it.
+# Legacy un-prefixed OAUTH_* spellings are also accepted (prefixed wins).
 # Optional:
 #   GUNDI_API_SSL_VERIFY
 
@@ -34,6 +35,11 @@ from datetime import datetime, timezone
 from gundi_client_v2 import GundiClient, GundiDataSenderClient
 
 
+def _env(name):
+    """Prefer the GUNDI_-prefixed spelling; fall back to the legacy bare name."""
+    return os.environ.get(f"GUNDI_{name}") or os.environ.get(name)
+
+
 def get_client_kwargs():
     """Build GundiClient kwargs from environment, validating required settings."""
     username = os.environ.get("GUNDI_USERNAME")
@@ -43,9 +49,9 @@ def get_client_kwargs():
             "Set GUNDI_USERNAME and GUNDI_PASSWORD in the environment, or pass them in code."
         )
 
-    oauth_client_id = os.environ.get("GUNDI_OAUTH_CLIENT_ID")
-    oauth_token_url = os.environ.get("GUNDI_OAUTH_TOKEN_URL")
-    oauth_issuer = os.environ.get("GUNDI_OAUTH_ISSUER")
+    oauth_client_id = _env("OAUTH_CLIENT_ID")
+    oauth_token_url = _env("OAUTH_TOKEN_URL")
+    oauth_issuer = _env("OAUTH_ISSUER")
     gundi_api_base_url = os.environ.get("GUNDI_API_BASE_URL")
 
     missing = []
@@ -69,8 +75,8 @@ def get_client_kwargs():
         kwargs["oauth_issuer"] = oauth_issuer
     kwargs["oauth_client_id"] = oauth_client_id
     kwargs["base_url"] = gundi_api_base_url
-    if os.environ.get("GUNDI_OAUTH_AUDIENCE"):
-        kwargs["oauth_audience"] = os.environ["GUNDI_OAUTH_AUDIENCE"]
+    if audience := _env("OAUTH_AUDIENCE"):
+        kwargs["oauth_audience"] = audience
     return kwargs
 
 

--- a/gundi_client_v2/__init__.py
+++ b/gundi_client_v2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.6.3"
+__version__ = "3.7.0"
 
 from .client import GundiClient, GundiDataSenderClient
 from .errors import GundiClientError, AuthenticationError, GundiAPIError

--- a/gundi_client_v2/cli/_client.py
+++ b/gundi_client_v2/cli/_client.py
@@ -21,11 +21,11 @@ from . import config_store, token_store
 
 T = TypeVar("T")
 
-# env var -> GundiClient kwarg. Always required.
-_REQUIRED_ENV = {
-    "GUNDI_API_BASE_URL": "base_url",
-    "OAUTH_CLIENT_ID": "oauth_client_id",
-}
+
+def _getenv(name: str) -> Optional[str]:
+    """Resolve an OAuth env var, preferring the GUNDI_-prefixed spelling
+    (``GUNDI_OAUTH_X``) over the bare ``OAUTH_X`` kept for backward compatibility."""
+    return os.environ.get(f"GUNDI_{name}") or os.environ.get(name)
 
 
 def build_client() -> GundiClient:
@@ -34,29 +34,34 @@ def build_client() -> GundiClient:
     Mirrors the library's auth rules. A ``client_id`` is always required, plus:
 
     - **Credentials** — either ``GUNDI_USERNAME`` + ``GUNDI_PASSWORD`` (password
-      grant, public client) or ``OAUTH_CLIENT_SECRET`` (client-credentials,
+      grant, public client) or ``GUNDI_OAUTH_CLIENT_SECRET`` (client-credentials,
       confidential client). When both are present the client uses the password
       grant.
-    - **Token endpoint** — ``OAUTH_ISSUER`` (preferred; resolved via OIDC
-      discovery, IdP-agnostic) or an explicit ``OAUTH_TOKEN_URL``. When both are
-      set, the explicit URL wins.
+    - **Token endpoint** — ``GUNDI_OAUTH_ISSUER`` (preferred; resolved via OIDC
+      discovery, IdP-agnostic) or an explicit ``GUNDI_OAUTH_TOKEN_URL``. When
+      both are set, the explicit URL wins.
 
-    ``OAUTH_AUDIENCE`` is forwarded when set (some IdPs require it). Exits with
-    code 2, listing what's missing, when required configuration is absent.
+    ``GUNDI_OAUTH_AUDIENCE`` is forwarded when set (some IdPs require it). Each
+    ``GUNDI_OAUTH_*`` var also accepts its bare ``OAUTH_*`` spelling for backward
+    compatibility. Exits with code 2, listing what's missing, when required
+    configuration is absent.
     """
     kwargs = {}
     missing = []
-    for env_name, kwarg in _REQUIRED_ENV.items():
-        if value := os.environ.get(env_name):
-            kwargs[kwarg] = value
-        else:
-            missing.append(env_name)
+    if base_url := os.environ.get("GUNDI_API_BASE_URL"):
+        kwargs["base_url"] = base_url
+    else:
+        missing.append("GUNDI_API_BASE_URL")
+    if client_id := _getenv("OAUTH_CLIENT_ID"):
+        kwargs["oauth_client_id"] = client_id
+    else:
+        missing.append("GUNDI_OAUTH_CLIENT_ID")
 
     # Credentials: password grant (username + password) or client-credentials
     # (client_secret). At least one full set is required.
     username = os.environ.get("GUNDI_USERNAME")
     password = os.environ.get("GUNDI_PASSWORD")
-    client_secret = os.environ.get("OAUTH_CLIENT_SECRET")
+    client_secret = _getenv("OAUTH_CLIENT_SECRET")
     if username:
         kwargs["username"] = username
     if password:
@@ -64,21 +69,22 @@ def build_client() -> GundiClient:
     if client_secret:
         kwargs["oauth_client_secret"] = client_secret
     if not (username and password) and not client_secret:
-        missing.append("OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD)")
+        missing.append("GUNDI_OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD)")
 
-    # Token endpoint: discovery via OAUTH_ISSUER preferred, OAUTH_TOKEN_URL is
-    # the explicit fallback. The client prefers oauth_token_url when both exist.
-    if issuer := os.environ.get("OAUTH_ISSUER"):
+    # Token endpoint: discovery via GUNDI_OAUTH_ISSUER preferred,
+    # GUNDI_OAUTH_TOKEN_URL is the explicit fallback. The client prefers
+    # oauth_token_url when both exist.
+    if issuer := _getenv("OAUTH_ISSUER"):
         kwargs["oauth_issuer"] = issuer
-    if token_url := os.environ.get("OAUTH_TOKEN_URL"):
+    if token_url := _getenv("OAUTH_TOKEN_URL"):
         kwargs["oauth_token_url"] = token_url
     if not issuer and not token_url:
-        missing.append("OAUTH_ISSUER (or OAUTH_TOKEN_URL)")
+        missing.append("GUNDI_OAUTH_ISSUER (or GUNDI_OAUTH_TOKEN_URL)")
 
     if missing:
         typer.echo(f"Error: missing required env vars: {', '.join(missing)}", err=True)
         raise typer.Exit(2)
-    if audience := os.environ.get("OAUTH_AUDIENCE"):
+    if audience := _getenv("OAUTH_AUDIENCE"):
         kwargs["oauth_audience"] = audience
     return GundiClient(**kwargs)
 
@@ -180,7 +186,7 @@ def _build_profile_client(env: dict) -> GundiClient:
     kwargs = _client_kwargs_from_env(env)
     if env.get("username") and (pw := os.environ.get("GUNDI_PASSWORD")):
         kwargs["password"] = pw
-    if secret := os.environ.get("OAUTH_CLIENT_SECRET"):
+    if secret := _getenv("OAUTH_CLIENT_SECRET"):
         kwargs["oauth_client_secret"] = secret
     return GundiClient(**kwargs)
 
@@ -205,9 +211,9 @@ def build_client_for_login(
             "Password", hide_input=True
         )
     else:
-        kwargs["oauth_client_secret"] = os.environ.get(
-            "OAUTH_CLIENT_SECRET"
-        ) or typer.prompt("Client secret", hide_input=True)
+        kwargs["oauth_client_secret"] = _getenv("OAUTH_CLIENT_SECRET") or typer.prompt(
+            "Client secret", hide_input=True
+        )
     return GundiClient(**kwargs)
 
 

--- a/gundi_client_v2/client.py
+++ b/gundi_client_v2/client.py
@@ -276,28 +276,31 @@ class GundiClient:
                 setting.
 
                 * ``oauth_client_id`` / ``keycloak_client_id`` (str):
-                  OAuth client ID. Env: ``OAUTH_CLIENT_ID`` /
-                  ``KEYCLOAK_CLIENT_ID``.
+                  OAuth client ID. Env: ``GUNDI_OAUTH_CLIENT_ID`` /
+                  ``OAUTH_CLIENT_ID`` / ``KEYCLOAK_CLIENT_ID``.
                 * ``oauth_client_secret`` / ``keycloak_client_secret``
                   (str): OAuth client secret (confidential clients). Env:
-                  ``OAUTH_CLIENT_SECRET`` / ``KEYCLOAK_CLIENT_SECRET``.
+                  ``GUNDI_OAUTH_CLIENT_SECRET`` / ``OAUTH_CLIENT_SECRET`` /
+                  ``KEYCLOAK_CLIENT_SECRET``.
                 * ``username`` (str): Resource-owner username (password
                   grant). Env: ``GUNDI_USERNAME``.
                 * ``password`` (str): Resource-owner password (password
                   grant). Env: ``GUNDI_PASSWORD``.
                 * ``oauth_token_url`` (str): Direct token endpoint URL.
                   Takes precedence over ``oauth_issuer``. Env:
-                  ``OAUTH_TOKEN_URL``.
+                  ``GUNDI_OAUTH_TOKEN_URL`` / ``OAUTH_TOKEN_URL``.
                 * ``oauth_issuer`` (str): OIDC issuer URL. Used for
                   automatic token-endpoint discovery when
-                  ``oauth_token_url`` is not set. Env: ``OAUTH_ISSUER`` /
+                  ``oauth_token_url`` is not set. Env:
+                  ``GUNDI_OAUTH_ISSUER`` / ``OAUTH_ISSUER`` /
                   ``KEYCLOAK_ISSUER``.
                 * ``oauth_audience`` / ``keycloak_audience`` (str): OAuth
                   audience claim. Required by Auth0; optional for
-                  Keycloak. Env: ``OAUTH_AUDIENCE`` /
-                  ``KEYCLOAK_AUDIENCE``.
+                  Keycloak. Env: ``GUNDI_OAUTH_AUDIENCE`` /
+                  ``OAUTH_AUDIENCE`` / ``KEYCLOAK_AUDIENCE``.
                 * ``oauth_scope`` (str): Space-separated OAuth scopes.
-                  Env: ``OAUTH_SCOPE`` (default ``"openid"``).
+                  Env: ``GUNDI_OAUTH_SCOPE`` / ``OAUTH_SCOPE`` (default
+                  ``"openid"``).
 
                 **Retry / timeout settings**
 

--- a/gundi_client_v2/settings.py
+++ b/gundi_client_v2/settings.py
@@ -15,17 +15,27 @@ else:
     # up the tree — matching how other dotenv-based tools behave.
     env.read_env(".env")
 
-# OAuth settings — OAUTH_* preferred; KEYCLOAK_* accepted for backward compatibility.
-# The token URL is either set directly via OAUTH_TOKEN_URL or discovered at runtime
-# from OAUTH_ISSUER via the OIDC discovery document.
-OAUTH_ISSUER = env.str("OAUTH_ISSUER", env.str("KEYCLOAK_ISSUER", None))
-OAUTH_TOKEN_URL = env.str("OAUTH_TOKEN_URL", None)
-OAUTH_CLIENT_ID = env.str("OAUTH_CLIENT_ID", env.str("KEYCLOAK_CLIENT_ID", None))
-OAUTH_CLIENT_SECRET = env.str(
-    "OAUTH_CLIENT_SECRET", env.str("KEYCLOAK_CLIENT_SECRET", None)
+# OAuth settings — GUNDI_OAUTH_* preferred; OAUTH_* and KEYCLOAK_* accepted for
+# backward compatibility. The token URL is either set directly via
+# GUNDI_OAUTH_TOKEN_URL or discovered at runtime from GUNDI_OAUTH_ISSUER via the
+# OIDC discovery document.
+OAUTH_ISSUER = env.str(
+    "GUNDI_OAUTH_ISSUER", env.str("OAUTH_ISSUER", env.str("KEYCLOAK_ISSUER", None))
 )
-OAUTH_AUDIENCE = env.str("OAUTH_AUDIENCE", env.str("KEYCLOAK_AUDIENCE", None))
-OAUTH_SCOPE = env.str("OAUTH_SCOPE", "openid")
+OAUTH_TOKEN_URL = env.str("GUNDI_OAUTH_TOKEN_URL", env.str("OAUTH_TOKEN_URL", None))
+OAUTH_CLIENT_ID = env.str(
+    "GUNDI_OAUTH_CLIENT_ID",
+    env.str("OAUTH_CLIENT_ID", env.str("KEYCLOAK_CLIENT_ID", None)),
+)
+OAUTH_CLIENT_SECRET = env.str(
+    "GUNDI_OAUTH_CLIENT_SECRET",
+    env.str("OAUTH_CLIENT_SECRET", env.str("KEYCLOAK_CLIENT_SECRET", None)),
+)
+OAUTH_AUDIENCE = env.str(
+    "GUNDI_OAUTH_AUDIENCE",
+    env.str("OAUTH_AUDIENCE", env.str("KEYCLOAK_AUDIENCE", None)),
+)
+OAUTH_SCOPE = env.str("GUNDI_OAUTH_SCOPE", env.str("OAUTH_SCOPE", "openid"))
 
 # Backward-compatible aliases for the pre-rename setting names. Code importing
 # gundi_client_v2.settings.KEYCLOAK_* keeps working; these mirror the OAUTH_* values.

--- a/tests/client/test_settings.py
+++ b/tests/client/test_settings.py
@@ -78,3 +78,74 @@ def test_envfile_overrides_cwd_dotenv(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     reloaded = importlib.reload(settings_module)
     assert reloaded.GUNDI_API_BASE_URL == "https://from-envfile.example"
+
+
+_GUNDI_OAUTH_VARS = (
+    "GUNDI_OAUTH_ISSUER",
+    "GUNDI_OAUTH_TOKEN_URL",
+    "GUNDI_OAUTH_CLIENT_ID",
+    "GUNDI_OAUTH_CLIENT_SECRET",
+    "GUNDI_OAUTH_AUDIENCE",
+    "GUNDI_OAUTH_SCOPE",
+)
+
+
+def _clear_oauth_env(monkeypatch):
+    """Drop every spelling of the OAuth vars so precedence tests start clean."""
+    for name in _GUNDI_OAUTH_VARS:
+        monkeypatch.delenv(name, raising=False)
+        monkeypatch.delenv(name.removeprefix("GUNDI_"), raising=False)
+        monkeypatch.delenv(name.replace("GUNDI_OAUTH_", "KEYCLOAK_"), raising=False)
+
+
+def test_gundi_oauth_names_work_alone(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("GUNDI_OAUTH_ISSUER", "https://idp.example.com/realms/x")
+    monkeypatch.setenv("GUNDI_OAUTH_TOKEN_URL", "https://idp.example.com/token")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_ID", "my-client")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_SECRET", "shhh")
+    monkeypatch.setenv("GUNDI_OAUTH_AUDIENCE", "gundi-api")
+    monkeypatch.setenv("GUNDI_OAUTH_SCOPE", "openid profile")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_ISSUER == "https://idp.example.com/realms/x"
+    assert reloaded.OAUTH_TOKEN_URL == "https://idp.example.com/token"
+    assert reloaded.OAUTH_CLIENT_ID == "my-client"
+    assert reloaded.OAUTH_CLIENT_SECRET == "shhh"
+    assert reloaded.OAUTH_AUDIENCE == "gundi-api"
+    assert reloaded.OAUTH_SCOPE == "openid profile"
+
+
+def test_gundi_oauth_prefix_wins_over_oauth_and_keycloak(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_ID", "prefixed")
+    monkeypatch.setenv("OAUTH_CLIENT_ID", "generic")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "legacy")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_CLIENT_ID == "prefixed"
+
+
+def test_oauth_still_wins_over_keycloak(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("OAUTH_CLIENT_ID", "generic")
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "legacy")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_CLIENT_ID == "generic"
+
+
+def test_keycloak_fallback_still_works(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "legacy")
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_CLIENT_ID == "legacy"
+    assert reloaded.KEYCLOAK_CLIENT_ID == "legacy"  # alias constant still mirrors
+
+
+def test_gundi_oauth_scope_default(monkeypatch, tmp_path):
+    _isolate_envfile(monkeypatch, tmp_path)
+    _clear_oauth_env(monkeypatch)
+    reloaded = importlib.reload(settings_module)
+    assert reloaded.OAUTH_SCOPE == "openid"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ def _clear_auth_env(monkeypatch):
     leak username/password/issuer into a test and change the selected grant.
     """
     for var in (
+        "OAUTH_CLIENT_ID",
         "OAUTH_CLIENT_SECRET",
         "OAUTH_TOKEN_URL",
         "OAUTH_ISSUER",
@@ -47,6 +48,7 @@ def _clear_auth_env(monkeypatch):
         "GUNDI_PASSWORD",
     ):
         monkeypatch.delenv(var, raising=False)
+        monkeypatch.delenv(f"GUNDI_{var}", raising=False)
 
 
 @pytest.fixture
@@ -334,14 +336,8 @@ def test_disable_patches_enabled_false(
 
 def test_missing_env_var_exits_2(monkeypatch):
     # No auth env vars set at all.
-    for var in (
-        "GUNDI_API_BASE_URL",
-        "OAUTH_CLIENT_ID",
-        "OAUTH_CLIENT_SECRET",
-        "OAUTH_TOKEN_URL",
-        "OAUTH_ISSUER",
-    ):
-        monkeypatch.delenv(var, raising=False)
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("GUNDI_API_BASE_URL", raising=False)
 
     result = runner.invoke(app, ["integrations", "list"])
 
@@ -353,6 +349,7 @@ def test_missing_env_var_exits_2(monkeypatch):
 
 def test_missing_token_endpoint_exits_2(monkeypatch):
     # Base creds present, but neither OAUTH_ISSUER nor OAUTH_TOKEN_URL is set.
+    _clear_auth_env(monkeypatch)
     monkeypatch.setenv("GUNDI_API_BASE_URL", BASE_URL)
     monkeypatch.setenv("OAUTH_CLIENT_ID", "confidential-client")
     monkeypatch.setenv("OAUTH_CLIENT_SECRET", "shhh")
@@ -1176,4 +1173,66 @@ def test_logs_by_type_slug_is_lowercased(cli_env, auth_token_response):
     assert result.exit_code == 0, result.output
     assert (
         logs_route.calls.last.request.url.params["integration_type"] == "earth_ranger"
+    )
+
+
+@pytest.fixture
+def cli_env_gundi_prefixed(monkeypatch):
+    """Client-credentials configured entirely via the new GUNDI_OAUTH_* names."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("GUNDI_API_BASE_URL", BASE_URL)
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_ID", "confidential-client")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_SECRET", "shhh")
+    monkeypatch.setenv("GUNDI_OAUTH_TOKEN_URL", TOKEN_URL)
+
+
+def test_list_with_gundi_prefixed_env(
+    cli_env_gundi_prefixed, auth_token_response, destination_integration_details
+):
+    with respx.mock(assert_all_called=False) as mock:
+        _mock_auth(mock, auth_token_response)
+        mock.get(INTEGRATIONS_URL).respond(
+            status_code=httpx.codes.OK,
+            json={"results": [destination_integration_details], "next": None},
+        )
+
+        result = runner.invoke(app, ["integrations", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert destination_integration_details["id"] in result.output
+
+
+def test_gundi_prefixed_wins_over_bare_name(
+    cli_env, auth_token_response, destination_integration_details, monkeypatch
+):
+    # cli_env sets the bare OAUTH_* names; the GUNDI_ spelling must win.
+    monkeypatch.setenv("OAUTH_CLIENT_SECRET", "wrong-secret")
+    monkeypatch.setenv("GUNDI_OAUTH_CLIENT_SECRET", "shhh")
+    with respx.mock(assert_all_called=False) as mock:
+        token_route = mock.post(TOKEN_URL).respond(
+            status_code=httpx.codes.OK, json=auth_token_response
+        )
+        mock.get(INTEGRATIONS_URL).respond(
+            status_code=httpx.codes.OK,
+            json={"results": [destination_integration_details], "next": None},
+        )
+
+        result = runner.invoke(app, ["integrations", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert b"client_secret=shhh" in token_route.calls.last.request.content
+
+
+def test_missing_env_error_names_gundi_prefixed_vars(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("GUNDI_API_BASE_URL", raising=False)
+
+    result = runner.invoke(app, ["integrations", "list"])
+
+    assert result.exit_code == 2, result.output
+    assert "GUNDI_OAUTH_CLIENT_ID" in result.output
+    assert "GUNDI_OAUTH_ISSUER (or GUNDI_OAUTH_TOKEN_URL)" in result.output
+    assert (
+        "GUNDI_OAUTH_CLIENT_SECRET (or GUNDI_USERNAME + GUNDI_PASSWORD)"
+        in result.output
     )

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -15,7 +15,12 @@ TOKEN_URL = f"{ISSUER}/protocol/openid-connect/token"
 def isolated_config(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.delenv("GUNDI_PROFILE", raising=False)
-    for var in ("OAUTH_CLIENT_SECRET", "GUNDI_PASSWORD", "GUNDI_USERNAME"):
+    for var in (
+        "OAUTH_CLIENT_SECRET",
+        "GUNDI_OAUTH_CLIENT_SECRET",
+        "GUNDI_PASSWORD",
+        "GUNDI_USERNAME",
+    ):
         monkeypatch.delenv(var, raising=False)
     return tmp_path
 


### PR DESCRIPTION
## Summary

Makes `GUNDI_OAUTH_*` the preferred env var names for OAuth configuration, avoiding collisions with other tools sharing an environment and matching the existing `GUNDI_`-prefixed vars (`GUNDI_API_BASE_URL`, `GUNDI_USERNAME`, ...). Old names keep working as silent fallbacks — no action required for existing setups.

- **Library** (`settings.py`): lookup chain `GUNDI_OAUTH_X` → `OAUTH_X` → `KEYCLOAK_X` (module constants keep their `OAUTH_*` names)
- **CLI** (`cli/_client.py`): new `_getenv()` helper preferring the prefixed spelling (`GUNDI_OAUTH_X` → `OAUTH_X`; the CLI never accepted `KEYCLOAK_*`); missing-config errors now name the new vars
- **Docs**: README, docs site, examples, `.env.example`, CLI skill, and `GundiClient` docstring switched to the new names; MIGRATION.md gains a 3.7.0 section with the old→new table
- **Version**: 3.7.0 (minor — no breaking change)

Design spec and implementation plan are included under `docs/superpowers/`.

## Test plan

- New precedence tests: `GUNDI_OAUTH_X` wins over `OAUTH_X` wins over `KEYCLOAK_X`; new names work alone; scope default preserved
- New CLI tests: full command run via `GUNDI_OAUTH_*` only; prefixed spelling wins over bare; error messages name the new vars
- All pre-existing old-name tests untouched and passing (back-compat regression suite): 232 passed, `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)